### PR TITLE
builtins: time.now_ns

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,8 +21,8 @@ jobs:
       - run: swift --version
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: make all
-      - name: make fmt lint (ComplianceSuite)
-        run: make fmt lint
+      - name: make fmt lint test (ComplianceSuite)
+        run: make fmt lint test
         working-directory: ComplianceSuite
       - run: make test-compliance || true # NB: This doesn't succeed yet!
 

--- a/ComplianceSuite/Makefile
+++ b/ComplianceSuite/Makefile
@@ -11,13 +11,19 @@ fmt:
 lint:
 	swift format lint --parallel --recursive .
 
+.PHONY: test
+test:
+	mkdir -p .build/test-results
+	swift test \
+	--xunit-output .build/test-results/junit.xml
+
 .PHONY: test-compliance
 test-compliance:
 	mkdir -p .build/test-results
 	OPA_COMPLIANCE_TESTS="$(OPA_COMPLIANCE_TESTS)" \
 		swift test \
 		--filter ComplianceTests.ComplianceTests \
-		--xunit-output .build/test-results/junit.xml
+		--xunit-output .build/test-results/junit-compliance.xml
 
 .PHONY: test-failed
 test-failed:

--- a/ComplianceSuite/Sources/RegoCompliance/RegoCompliance.swift
+++ b/ComplianceSuite/Sources/RegoCompliance/RegoCompliance.swift
@@ -202,7 +202,9 @@ public struct ComplianceTesting {
         public var knownIssue: String?
     }
 
-    public static func runTest(config: TestConfig, _ tc: IRTestCase) async -> IRTestResult {
+    public static func runTest(config: TestConfig, _ tc: IRTestCase, _ customBuiltins: [String: Builtin] = [:]) async
+        -> IRTestResult
+    {
         var testResult = IRTestResult(testCase: tc)
 
         for knownIssue in config.knownIssues {
@@ -228,7 +230,7 @@ public struct ComplianceTesting {
             ])
         )
 
-        var engine = OPA.Engine(policies: [tc.base.plan], store: store)
+        var engine = OPA.Engine(policies: [tc.base.plan], store: store, customBuiltins: customBuiltins)
 
         // The logic - ignore query and want.
         // We care about entrypoints and want_plan_result, which have been teased out to

--- a/ComplianceSuite/Tests/RegoComplianceTests/ParseDurationTests.swift
+++ b/ComplianceSuite/Tests/RegoComplianceTests/ParseDurationTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@Suite("Duration Parsing Tests")
+struct ParseDurationTests {
+    static let durationArguments: [(String, Int)] = [
+        ("5s", 5 * 1_000_000_000),
+        ("5ms", 5 * 1_000_000),
+        ("5us", 5 * 1_000),
+        ("5µs", 5 * 1_000),
+        ("5ns", 5),
+        ("1m", 1 * 60 * 1_000_000_000),
+        ("1h", 1 * 60 * 60 * 1_000_000_000),
+        // Negative values
+        ("-3µs", -3 * 1_000),
+        // Composite Values
+        ("1m10s", 1 * 60 * 1_000_000_000 + 10 * 1_000_000_000),
+        ("1h10m11s5ms", 1 * 60 * 60 * 1_000_000_000 + 10 * 60 * 1_000_000_000 + 11 * 1_000_000_000 + 5 * 1_000_000),
+        ("10ns10ns", 20),
+        (" 10ns ", 10),  // spaces are successfully ignored
+    ]
+
+    @Test(arguments: durationArguments)
+    func parseValidDurationsTest(arg: (String, Int)) {
+        let result = try? TestBuiltins.parseDurationNanoseconds(arg.0)
+        #expect(result != nil)
+        #expect(result! == arg.1)
+    }
+
+    static let invalidDurations: [String] = [
+        "1",  // no unit
+        "1f",  // unknown unit
+        "Ams",  // not a numeric value
+        "--1m",  // double minus
+        "1m 10s",  // space in the middle is not okay
+        "1m10s foo",  // unknown string at the end
+    ]
+
+    @Test(arguments: invalidDurations)
+    func parseInvalidDurationsTest(arg: String) {
+        #expect(throws: TestBuiltins.DurationParseError.invalidFormat) {
+            try TestBuiltins.parseDurationNanoseconds(arg)
+        }
+    }
+
+}

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -6,12 +6,16 @@ public typealias Builtin = @Sendable (BuiltinContext, [AST.RegoValue]) async thr
 public struct BuiltinContext {
     public let location: OPA.Trace.Location
     public var tracer: OPA.Trace.QueryTracer?
+    /// Date and Time of Context creation
+    public let timestamp: Date
     internal let cache: Ptr<BuiltinsCache>
 
     init(
+
         location: OPA.Trace.Location = .init(),
         tracer: OPA.Trace.QueryTracer? = nil,
-        cache: Ptr<BuiltinsCache>? = nil
+        cache: Ptr<BuiltinsCache>? = nil,
+        timestamp: Date? = nil
     ) {
         self.location = location
         self.tracer = tracer
@@ -19,6 +23,7 @@ public struct BuiltinContext {
         // some builtin evaluations (e.g. UUID) expect the cache.
         // In most/all? cases, we expect a shared cache to be passed in here from EvaluationContext
         self.cache = cache ?? Ptr<BuiltinsCache>(toCopyOf: BuiltinsCache())
+        self.timestamp = timestamp ?? Date()
     }
 }
 
@@ -136,6 +141,9 @@ public struct BuiltinRegistry: Sendable {
             "trim_space": BuiltinFuncs.trimSpace,
             "trim_suffix": BuiltinFuncs.trimSuffix,
             "upper": BuiltinFuncs.upper,
+
+            // Time
+            "time.now_ns": BuiltinFuncs.timeNowNanos,
 
             // Trace
             "trace": BuiltinFuncs.trace,

--- a/Sources/Rego/Builtins/Time.swift
+++ b/Sources/Rego/Builtins/Time.swift
@@ -1,0 +1,15 @@
+import AST
+import Foundation
+
+extension BuiltinFuncs {
+    static func timeNowNanos(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 0 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 0)
+        }
+        // Note that the value of the "now" is pinned to the value in the BuiltinContext.
+        // This is done so that multiple calls to this built-in function within a single policy evaluation query
+        // will always return the same value.
+        // This is by design and is documented in https://www.openpolicyagent.org/docs/latest/policy-reference/#time
+        return .number(NSNumber(value: ctx.timestamp.timeIntervalSince1970 * 1_000_000_000))
+    }
+}

--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -138,12 +138,13 @@ extension OPA.Engine {
         guard conflictingBuiltins.isEmpty else {
             throw RegoError(
                 code: .ambiguousBuiltinError,
-                message: "encountered conflicting builtin names between custom and default builtins: \(conflictingBuiltins)"
+                message:
+                    "encountered conflicting builtin names between custom and default builtins: \(conflictingBuiltins)"
             )
         }
         let builtins = self.customBuiltins.merging(
             registryBuiltins,
-            uniquingKeysWith: { $1 }    // should never happen, see guard above
+            uniquingKeysWith: { $1 }  // should never happen, see guard above
         )
         let mergedBuiltinRegistry = BuiltinRegistry(builtins: builtins)
 
@@ -191,7 +192,8 @@ extension OPA.Engine {
         }
 
         // Verifies that builtins are available in the OPA capabilities and builtin registry
-        try await Self.verifyCapabilitiesAndBuiltIns(capabilities: self.capabilities, builtins: builtins, evaluator: evaluator)
+        try await Self.verifyCapabilitiesAndBuiltIns(
+            capabilities: self.capabilities, builtins: builtins, evaluator: evaluator)
 
         return PreparedQuery(
             query: query,

--- a/Sources/Rego/Evaluator.swift
+++ b/Sources/Rego/Evaluator.swift
@@ -1,5 +1,6 @@
 // Evaluator.swift - this file contains code related to evaluating an Rego IR Plan.
 import AST
+import Foundation
 import IR
 
 protocol Evaluator: Sendable {
@@ -14,6 +15,8 @@ internal struct EvaluationContext {
     public var builtins: BuiltinRegistry
     public var tracer: OPA.Trace.QueryTracer?
     public var strictBuiltins: Bool = false
+    /// Date and Time of Context creation
+    public let timestamp: Date
 
     init(
         query: String,
@@ -21,7 +24,8 @@ internal struct EvaluationContext {
         store: OPA.Store = NullStore(),
         builtins: BuiltinRegistry = .defaultRegistry,
         tracer: OPA.Trace.QueryTracer? = nil,
-        strictBuiltins: Bool = false
+        strictBuiltins: Bool = false,
+        timestamp: Date? = nil
     ) {
         self.query = query
         self.input = input
@@ -29,6 +33,7 @@ internal struct EvaluationContext {
         self.builtins = builtins
         self.tracer = tracer
         self.strictBuiltins = strictBuiltins
+        self.timestamp = timestamp ?? Date()
     }
 }
 

--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -1032,7 +1032,8 @@ private func evalCall(
 
     let bctx = BuiltinContext(
         location: try frame.v.currentLocation(withContext: ctx, stmt: caller),
-        tracer: ctx.ctx.tracer
+        tracer: ctx.ctx.tracer,
+        timestamp: ctx.ctx.timestamp
     )
 
     return try await ctx.ctx.builtins.invoke(

--- a/Tests/RegoTests/BuiltinTests/BuiltinTests.swift
+++ b/Tests/RegoTests/BuiltinTests/BuiltinTests.swift
@@ -108,32 +108,8 @@ struct BuiltinTests {
         ]
         var tests: [BuiltinTests.TestCase] = []
         if generateNumberOfArgsTest {
-            // Only generate "too few" test case when expected number of arguments is > 0
-            if sampleArgs.count > 0 {
-                tests.append(
-                    BuiltinTests.TestCase(
-                        description: "wrong number of arguments (too few)",
-                        name: builtinName,
-                        args: [],
-                        expected: .failure(
-                            BuiltinError.argumentCountMismatch(got: 0, want: sampleArgs.count))
-                    )
-                )
-            }
-            // too many args case
-            var tooManyArgs = sampleArgs  // copy
-            tooManyArgs.append(.null)
             tests.append(
-                BuiltinTests.TestCase(
-                    description: "wrong number of arguments (too many) with " + String(tooManyArgs.count)
-                        + " arguments",
-                    name: builtinName,
-                    args: tooManyArgs,
-                    expected: .failure(
-                        BuiltinError.argumentCountMismatch(
-                            got: tooManyArgs.count, want: sampleArgs.count))
-                )
-            )
+                contentsOf: generateNumberOfArgumentsFailureTests(builtinName: builtinName, sampleArgs: sampleArgs))
         }
         // Formulating "want" part of the error message:
         // when passed explicitly, we will use the expression passed in
@@ -157,6 +133,47 @@ struct BuiltinTests {
                 )
             )
         }
+
+        return tests
+    }
+
+    /// For covering argument count checks ONLY,
+    /// this method generates a series of tests for correct number of arguments being passed into a builtin.
+    /// Returns a list of test cases.
+    /// - Parameters:
+    ///   - builtinName: The name of the builtin function being tested.
+    ///   - sampleArgs: The sample arguments to use. Use correct arguments for the builtin you are testing.
+    static func generateNumberOfArgumentsFailureTests(
+        builtinName: String,
+        sampleArgs: [RegoValue]
+    ) -> [BuiltinTests.TestCase] {
+        var tests: [BuiltinTests.TestCase] = []
+        // Only generate "too few" test case when expected number of arguments is > 0
+        if sampleArgs.count > 0 {
+            tests.append(
+                BuiltinTests.TestCase(
+                    description: "wrong number of arguments (too few)",
+                    name: builtinName,
+                    args: [],
+                    expected: .failure(
+                        BuiltinError.argumentCountMismatch(got: 0, want: sampleArgs.count))
+                )
+            )
+        }
+        // Too many args case
+        var tooManyArgs = sampleArgs  // copy
+        tooManyArgs.append(.null)
+        tests.append(
+            BuiltinTests.TestCase(
+                description: "wrong number of arguments (too many) with " + String(tooManyArgs.count)
+                    + (tooManyArgs.count == 1 ? " argument" : " arguments"),
+                name: builtinName,
+                args: tooManyArgs,
+                expected: .failure(
+                    BuiltinError.argumentCountMismatch(
+                        got: tooManyArgs.count, want: sampleArgs.count))
+            )
+        )
 
         return tests
     }

--- a/Tests/RegoTests/BuiltinTests/TimeTests.swift
+++ b/Tests/RegoTests/BuiltinTests/TimeTests.swift
@@ -1,0 +1,73 @@
+import AST
+import Foundation
+import Testing
+
+@testable import Rego
+
+extension BuiltinTests {
+    @Suite("BuiltinTests - Time", .tags(.builtins))
+    struct TimeTests {}
+}
+
+extension BuiltinTests.TimeTests {
+    static var allTests: [BuiltinTests.TestCase] {
+        [
+            BuiltinTests.generateNumberOfArgumentsFailureTests(
+                builtinName: "time.now_ns", sampleArgs: [])
+        ].flatMap { $0 }
+    }
+
+    @Test(arguments: allTests)
+    func testBuiltins(tc: BuiltinTests.TestCase) async throws {
+        try await BuiltinTests.testBuiltin(tc: tc)
+    }
+
+    @Test
+    func timeNowNanosReturnsValidTime() async throws {
+        let expected = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext()
+        let result = try await reg.invoke(withContext: ctx, name: "time.now_ns", args: [], strict: true)
+        // Make sure the output is *actually* an integer that represents time
+        switch result {
+        case .number(let actual):
+            #expect(actual.uint64Value >= expected)
+        default:
+            Issue.record("time.now_ns should return a number, but got: \(result)")
+        }
+    }
+
+    @Test
+    func timeNowNanosReturnsTimeFromContext() async throws {
+        let expected = Date()
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext(timestamp: expected)
+        let result = try await reg.invoke(withContext: ctx, name: "time.now_ns", args: [], strict: true)
+        // Make sure the output is *actually* an integer that represents current time
+        switch result {
+        case .number(let actual):
+            #expect(actual.uint64Value == UInt64(expected.timeIntervalSince1970 * 1_000_000_000))
+        default:
+            Issue.record("time.now_ns should return a number, but got: \(result)")
+        }
+    }
+
+    @Test
+    func timeNowNanosReturnsSameValueForSameContext() async throws {
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext()
+        let result1 = try await reg.invoke(withContext: ctx, name: "time.now_ns", args: [], strict: true)
+        let result2 = try await reg.invoke(withContext: ctx, name: "time.now_ns", args: [], strict: true)
+        #expect(result1 == result2)
+    }
+
+    @Test
+    func timeNowNanosReturnsDifferentValuesForDifferentContexts() async throws {
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx1 = BuiltinContext()
+        let ctx2 = BuiltinContext(timestamp: ctx1.timestamp.addingTimeInterval(2))
+        let result1 = try await reg.invoke(withContext: ctx1, name: "time.now_ns", args: [], strict: true)
+        let result2 = try await reg.invoke(withContext: ctx2, name: "time.now_ns", args: [], strict: true)
+        #expect(result2 > result1)
+    }
+}


### PR DESCRIPTION
Implement time.now_ns builtin maintaining compatibility with Go version.

Resolves #4 