### PR TITLE
add initializer for RegoValue from Encodable

### DIFF
--- a/Sources/AST/RegoValue+Codable.swift
+++ b/Sources/AST/RegoValue+Codable.swift
@@ -45,6 +45,11 @@ extension RegoValue: Codable {
         try self.init(from: d)
     }
 
+    // Initialize a RegoValue from a type that can be JSON-encoded
+    public init(encodable: Encodable) throws {
+        try self.init(jsonData: try JSONEncoder().encode(encodable))
+    }
+
     // Decodable initializer
     public init(from decoder: Decoder) throws {
         // Try as an object

--- a/Tests/ASTTests/RegoValueTests.swift
+++ b/Tests/ASTTests/RegoValueTests.swift
@@ -75,6 +75,65 @@ func testJsonToRegoValues() throws {
 }
 
 @Test
+func testEncodableToRegoValues() throws {
+    struct Input: Encodable {
+        let pets: [Pet]
+
+        struct Pet: Encodable {
+            let name: String
+            let age: Int
+            let sibling: String?
+            let weight: Double
+            let hasChildren: Bool
+            let hasBlueEyes: Bool
+            let children: [String]
+            let zero: Int
+            let one: Int
+        }
+    }
+
+    let input = Input(
+        pets: [
+            .init(
+                name: "Mr. Meowgi",
+                age: 4,
+                sibling: nil,
+                weight: 12.5,
+                hasChildren: true,
+                hasBlueEyes: false,
+                children: [
+                    "Wax On",
+                    "Wax Off",
+                ],
+                zero: 0,
+                one: 1,
+            )
+        ]
+    )
+    let val = try AST.RegoValue(encodable: input)
+
+    let expected: RegoValue = [
+        "pets": [
+            [
+                "name": "Mr. Meowgi",
+                "age": 4,
+                // With the default JSONEncoder, nil Optionals are not included in the serialized JSON, so 'sibling' is missing.
+                "weight": 12.5,
+                "hasChildren": true,
+                "hasBlueEyes": false,
+                "children": [
+                    "Wax On",
+                    "Wax Off",
+                ],
+                "zero": 0,
+                "one": 1,
+            ]
+        ]
+    ]
+    #expect(expected == val, "output did not match expectations")
+}
+
+@Test
 func testNumberIsInteger() throws {
     // Integers
     #expect(AST.RegoValue.number(0).integerValue == 0)


### PR DESCRIPTION
Call me lazy, but I didn't want to have to import Foundation or type the one-liner to encode my Encodable as JSON and pass it to the `AST.RegoValue.init(jsonData:)`.

This adds a new initializer that accepts an Encodable type, which I imagine being used frequently for authorization checks using dynamic input.

Do feel free to just call me lazy and force me to pass Data everywhere 😂 