### PR TITLE
fix inconsistent results when combining bundles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+plan.json linguist-generated=true

--- a/Tests/RegoTests/TestData/Bundles/basic-policy-no-data-bundle/.manifest
+++ b/Tests/RegoTests/TestData/Bundles/basic-policy-no-data-bundle/.manifest
@@ -1,0 +1,1 @@
+{"revision":"792f5298-a797-4877-924d-f37bf4f76633","roots":["app"],"rego_version":1,"metadata":{"name":"example-basic"}}

--- a/Tests/RegoTests/TestData/Bundles/basic-policy-no-data-bundle/app/basic.rego
+++ b/Tests/RegoTests/TestData/Bundles/basic-policy-no-data-bundle/app/basic.rego
@@ -1,0 +1,9 @@
+package app.basic
+
+# By default, deny requests.
+default allow := false
+
+allow if {
+	some apple in data.apples
+	input.variety == apple.variety
+}

--- a/Tests/RegoTests/TestData/Bundles/basic-policy-no-data-bundle/plan.json
+++ b/Tests/RegoTests/TestData/Bundles/basic-policy-no-data-bundle/plan.json
@@ -1,0 +1,366 @@
+{
+  "funcs": {
+    "funcs": [
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 6,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 2,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 7,
+                  "source": {
+                    "type": "local",
+                    "value": 1
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "block": {
+                    "stmts": [
+                      {
+                        "stmt": {
+                          "col": 2,
+                          "file": 0,
+                          "row": 7,
+                          "source": {
+                            "type": "local",
+                            "value": 5
+                          },
+                          "target": 7
+                        },
+                        "type": "AssignVarStmt"
+                      },
+                      {
+                        "stmt": {
+                          "blocks": [
+                            {
+                              "stmts": [
+                                {
+                                  "stmt": {
+                                    "blocks": [
+                                      {
+                                        "stmts": [
+                                          {
+                                            "stmt": {
+                                              "col": 2,
+                                              "file": 0,
+                                              "index": 1,
+                                              "row": 7
+                                            },
+                                            "type": "BreakStmt"
+                                          }
+                                        ]
+                                      }
+                                    ],
+                                    "col": 2,
+                                    "file": 0,
+                                    "row": 7
+                                  },
+                                  "type": "BlockStmt"
+                                },
+                                {
+                                  "stmt": {
+                                    "col": 2,
+                                    "file": 0,
+                                    "index": 1,
+                                    "row": 7
+                                  },
+                                  "type": "BreakStmt"
+                                }
+                              ]
+                            }
+                          ],
+                          "col": 2,
+                          "file": 0,
+                          "row": 7
+                        },
+                        "type": "BlockStmt"
+                      },
+                      {
+                        "stmt": {
+                          "col": 2,
+                          "file": 0,
+                          "row": 7,
+                          "source": {
+                            "type": "local",
+                            "value": 6
+                          },
+                          "target": 10
+                        },
+                        "type": "AssignVarStmt"
+                      },
+                      {
+                        "stmt": {
+                          "col": 2,
+                          "file": 0,
+                          "key": {
+                            "type": "string_index",
+                            "value": 2
+                          },
+                          "row": 8,
+                          "source": {
+                            "type": "local",
+                            "value": 0
+                          },
+                          "target": 11
+                        },
+                        "type": "DotStmt"
+                      },
+                      {
+                        "stmt": {
+                          "col": 2,
+                          "file": 0,
+                          "key": {
+                            "type": "string_index",
+                            "value": 2
+                          },
+                          "row": 8,
+                          "source": {
+                            "type": "local",
+                            "value": 10
+                          },
+                          "target": 12
+                        },
+                        "type": "DotStmt"
+                      },
+                      {
+                        "stmt": {
+                          "a": {
+                            "type": "local",
+                            "value": 11
+                          },
+                          "b": {
+                            "type": "local",
+                            "value": 12
+                          },
+                          "col": 2,
+                          "file": 0,
+                          "row": 8
+                        },
+                        "type": "EqualStmt"
+                      },
+                      {
+                        "stmt": {
+                          "col": 1,
+                          "file": 0,
+                          "row": 6,
+                          "source": {
+                            "type": "bool",
+                            "value": true
+                          },
+                          "target": 3
+                        },
+                        "type": "AssignVarOnceStmt"
+                      }
+                    ]
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "key": 5,
+                  "row": 7,
+                  "source": 4,
+                  "value": 6
+                },
+                "type": "ScanStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 6,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 6,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 9,
+                  "file": 0,
+                  "row": 4,
+                  "source": 2
+                },
+                "type": "IsUndefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 9,
+                  "file": 0,
+                  "row": 4,
+                  "source": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 9,
+                  "file": 0,
+                  "row": 4,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.app.basic.allow",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "app",
+          "basic",
+          "allow"
+        ],
+        "return": 2
+      }
+    ]
+  },
+  "plans": {
+    "plans": [
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 0,
+                  "file": 0,
+                  "func": "g0.data.app.basic.allow",
+                  "result": 2,
+                  "row": 0
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "row": 0,
+                  "source": {
+                    "type": "local",
+                    "value": 2
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "row": 0,
+                  "target": 4
+                },
+                "type": "MakeObjectStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 0
+                  },
+                  "object": 4,
+                  "row": 0,
+                  "value": {
+                    "type": "local",
+                    "value": 3
+                  }
+                },
+                "type": "ObjectInsertStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "row": 0,
+                  "value": 4
+                },
+                "type": "ResultSetAddStmt"
+              }
+            ]
+          }
+        ],
+        "name": "app/basic/allow"
+      }
+    ]
+  },
+  "static": {
+    "files": [
+      {
+        "value": "app/basic.rego"
+      }
+    ],
+    "strings": [
+      {
+        "value": "result"
+      },
+      {
+        "value": "apples"
+      },
+      {
+        "value": "variety"
+      }
+    ]
+  }
+}

--- a/Tests/RegoTests/TestData/Bundles/basic-policy-only-data-bundle/.manifest
+++ b/Tests/RegoTests/TestData/Bundles/basic-policy-only-data-bundle/.manifest
@@ -1,0 +1,1 @@
+{"revision":"bb0a3ebe-043c-43c4-860a-b3085c7c11c0","roots":["apples"],"rego_version":1,"metadata":{"name":"example-basic"}}

--- a/Tests/RegoTests/TestData/Bundles/basic-policy-only-data-bundle/data.json
+++ b/Tests/RegoTests/TestData/Bundles/basic-policy-only-data-bundle/data.json
@@ -1,0 +1,12 @@
+{
+  "apples": [
+    {
+      "variety": "cosmic crisp",
+      "rating": 5
+    },
+    {
+      "variety": "red delicious",
+      "rating": 0
+    }
+  ]
+}


### PR DESCRIPTION
When testing with `opa` CLI you will consistently get `allow == true`

```shell
$ opa eval \
    -i <(printf '{"variety": "cosmic crisp"}') \
    -b Tests/RegoTests/TestData/Bundles/basic-policy-no-data-bundle \
    -b Tests/RegoTests/TestData/Bundles/basic-policy-only-data-bundle \
    data.app.basic.allow | jq '.result[].expressions[].value'
true
```

But, the same case in our tests around `OPA.Engine` is flaky:

```shell
$ make test | rg 'separate bundles with rego and data'
...
◇ Passing 1 argument tc → happy path basic, separate bundles with rego and data to testValidEvaluations(tc:)

$ make test | rg 'separate bundles with rego and data'
...
◇ Passing 1 argument tc → happy path basic, separate bundles with rego and data to testValidEvaluations(tc:)
✘ Test testValidEvaluations(tc:) recorded an issue with 1 argument tc → happy path basic, separate bundles with rego and data at IREvaluatorTests.swift:175:9: Expectation failed: (tc.expectedResult → [AST.RegoValue.object([AST.RegoValue.string("result"): AST.RegoValue.boolean(true)])]) == (actual → [AST.RegoValue.object([AST.RegoValue.string("result"): AST.RegoValue.boolean(false)])])
make: *** [test] Error 1
```