### PR TITLE
convert Engine initializer to non throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import Foundation
 
 let path = "some/local/path"
 let bundlePath = OPA.Engine.BundlePath(name: "policyBundle", url: URL(fileURLWithPath: path))
-var regoEngine = try OPA.Engine(bundlePaths: [bundlePath])
+var regoEngine = OPA.Engine(bundlePaths: [bundlePath])
 
 // Prepare does as much pre-processing as possible to get ready to evaluate queries.
 // This only needs to be done once when loading the engine and after updating it.

--- a/Sources/CLI/BenchCommand.swift
+++ b/Sources/CLI/BenchCommand.swift
@@ -16,7 +16,7 @@ struct BenchCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         // Initialize a Rego.Engine initially configured with our bundles from the CLI options.
-        var regoEngine = try Rego.OPA.Engine(bundlePaths: self.evalOptions.bundlePaths)
+        var regoEngine = Rego.OPA.Engine(bundlePaths: self.evalOptions.bundlePaths)
 
         // Prepare does as much pre-processing as possible to get ready to evaluate queries.
         // This only needs to be done once when loading the engine and after updating it.

--- a/Sources/CLI/EvalCommand.swift
+++ b/Sources/CLI/EvalCommand.swift
@@ -14,7 +14,7 @@ struct EvalCommand: AsyncParsableCommand {
 
     mutating func run() async throws {
         // Initialize a Rego.Engine initially configured with our bundles from the CLI options.
-        var regoEngine = try Rego.OPA.Engine(bundlePaths: self.evalOptions.bundlePaths)
+        var regoEngine = Rego.OPA.Engine(bundlePaths: self.evalOptions.bundlePaths)
 
         let tracer = tracerForLevel(self.evalOptions.explain)
 

--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -20,7 +20,7 @@ extension OPA {
 }
 
 extension OPA.Engine {
-    public init(bundlePaths: [BundlePath]) throws {
+    public init(bundlePaths: [BundlePath]) {
         self.bundlePaths = bundlePaths
     }
     public init(bundles: [String: OPA.Bundle]) {

--- a/Tests/RegoTests/IREvaluatorTests.swift
+++ b/Tests/RegoTests/IREvaluatorTests.swift
@@ -133,7 +133,7 @@ struct IREvaluatorTests {
 
     @Test(arguments: validTestCases)
     func testValidEvaluations(tc: TestCase) async throws {
-        var engine = try OPA.Engine(bundlePaths: [OPA.Engine.BundlePath(name: "default", url: tc.sourceBundle)])
+        var engine = OPA.Engine(bundlePaths: [OPA.Engine.BundlePath(name: "default", url: tc.sourceBundle)])
         let bufferTracer = OPA.Trace.BufferedQueryTracer(level: .full)
         let actual = try await engine.prepareForEvaluation(query: tc.query).evaluate(
             input: tc.input,
@@ -160,7 +160,7 @@ struct IREvaluatorTests {
 
     @Test(arguments: errorTestCases)
     func testInvalidEvaluations(tc: ErrorCase) async throws {
-        var engine = try OPA.Engine(bundlePaths: [OPA.Engine.BundlePath(name: "default", url: tc.sourceBundle)])
+        var engine = OPA.Engine(bundlePaths: [OPA.Engine.BundlePath(name: "default", url: tc.sourceBundle)])
 
         await #expect(Comment(rawValue: tc.description)) {
             let _ = try await engine.prepareForEvaluation(query: tc.query).evaluate(input: tc.input)


### PR DESCRIPTION
Bundle validation is largely handled in `OPA.Engine.prepareForEvaluation`, and the initializer itself doesn't have any reason to throw.

If we want to reserve the right to throw from this initializer in the future, we can leave this in, but the `init(bundles:)` should also be updated to throw.

At first glance, this looks like a breaking change, but it actually just causes a warning if you still `try` the init. For example, you'd see a warning like this:
>  warning: no calls to throwing functions occur within 'try' expression