### PR TITLE
docs: README wording fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Swift-OPA is a Swift package for evaluating [OPA IR
 Plans](https://www.openpolicyagent.org/docs/latest/ir/) compiled from
 [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/#what-is-rego)
-declarative policy.
+policies.
 
 Rego is a declarative language for expressing policy over structured data. A
 common use of Rego is for defining authorization policy.


### PR DESCRIPTION
'Rego declarative policy' is generally not the phrasing we use elsewhere, I have updated this to be just 'Rego policies'.

The link to Rego and IR links should be more than enough to fill in blanks in readers understandings.

NOTE: We will also need to get the repo description field updated (I do not have permissions for that)