### PR TITLE
fix: benchmark unit conversions and formatting

### DIFF
--- a/Sources/CLI/Duration+Format.swift
+++ b/Sources/CLI/Duration+Format.swift
@@ -47,25 +47,21 @@ struct NanosecondsDurationStyle: FormatStyle, Sendable {
 }
 
 private let attosecondsPerSecond = Double(1e18)
-private let nanosecondsPerSecond = Double(1e9)
-private let microsecondsPerSecond = Double(1e6)
-private let millisecondsPerSecond = Double(1e3)
-
-private let nanosecondsPerAtto = Double(1e9)
-private let microsecondsPerAtto = Double(1e12)
-private let millisecondsPerAtto = Double(1e15)
+private let attosecondsPerNanosecond = Double(1e9)
+private let attosecondsPerMicrosecond = Double(1e12)
+private let attosecondsPerMillisecond = Double(1e15)
 
 extension Duration {
     var seconds: Double {
         return Double(self.components.attoseconds) / attosecondsPerSecond
     }
     var nanoseconds: Double {
-        return Double(self.components.attoseconds) / nanosecondsPerAtto
+        return Double(self.components.attoseconds) / attosecondsPerNanosecond
     }
     var microseconds: Double {
-        return Double(self.components.attoseconds) / microsecondsPerAtto
+        return Double(self.components.attoseconds) / attosecondsPerMicrosecond
     }
     var milliseconds: Double {
-        return Double(self.components.attoseconds) / millisecondsPerSecond
+        return Double(self.components.attoseconds) / attosecondsPerMillisecond
     }
 }

--- a/Sources/CLI/Measure+Format.swift
+++ b/Sources/CLI/Measure+Format.swift
@@ -27,20 +27,21 @@ struct GobenchStyle: FormatStyle, Sendable {
         // Figure out which units are closest
         var value: String = ""
         var unit: String = ""
+        let style: FloatingPointFormatStyle<Double> = .number.precision(.fractionLength(0...4))
         if v.components.seconds >= 1 {
-            value = v.seconds.formatted(.number.precision(.fractionLength(0...4)))
+            value = v.seconds.formatted(style)
             unit = "s/op"
         } else if 1..<1000 ~= v.milliseconds {
-            value = v.milliseconds.formatted(.number.precision(.fractionLength(0...4)))
+            value = v.milliseconds.formatted(style)
             unit = "ms/op"
         } else if 1..<1000 ~= v.microseconds {
-            value = v.microseconds.formatted(.number.precision(.fractionLength(0...4)))
+            value = v.microseconds.formatted(style)
             unit = "μs/op"
         } else if 1..<1000 ~= v.nanoseconds {
-            value = v.nanoseconds.formatted(.number.precision(.fractionLength(0...4)))
+            value = v.nanoseconds.formatted(style)
             unit = "ns/op"
         } else {
-            value = v.components.attoseconds.formatted(.number.precision(.fractionLength(0...4)))
+            value = v.components.attoseconds.formatted(.number.grouping(.automatic))
             unit = "as/op"
         }
         return "Benchmark\t\(report.iterations)\t\(value) \(unit)"


### PR DESCRIPTION
Fix unit conversions and formatting in the CLI `bench` command.