### PR TITLE
builtins: Handle bit shifts overflowing the number representation.

### DIFF
--- a/Sources/Rego/Builtins/Bits.swift
+++ b/Sources/Rego/Builtins/Bits.swift
@@ -22,12 +22,19 @@ extension BuiltinFuncs {
         guard intB >= 0 else {
             throw BuiltinError.argumentTypeMismatch(arg: "b", got: "negative integer", want: "unsigned integer")
         }
-        // This prevents large integers from overflowing
-        // and is explicitly verified by the compliance suite
-        if intA > 0 {
-            return AST.RegoValue.number(NSNumber(value: (UInt64(intA) << intB)))
+        // Shifts >= 64 bits return 0
+        guard intB < 64 else {
+            return AST.RegoValue.number(NSNumber(value: 0))
         }
-        return AST.RegoValue.number(NSNumber(value: Int64(intA << intB)))
+
+        // For positive numbers, use unsigned arithmetic to handle cases
+        // where shifting would move bits into the sign bit position
+        if intA > 0 {
+            return AST.RegoValue.number(NSNumber(value: UInt64(intA) << intB))
+        }
+
+        // For negative numbers or zero, use signed arithmetic with wrapping
+        return AST.RegoValue.number(NSNumber(value: intA &<< intB))
     }
 
     static func bitsShiftRight(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
@@ -51,7 +58,12 @@ extension BuiltinFuncs {
             throw BuiltinError.argumentTypeMismatch(arg: "b", got: "negative integer", want: "unsigned integer")
         }
 
-        return AST.RegoValue.number(NSNumber(value: Int64(intA >> intB)))
+        // Shifts >= 64 bits result in 0 or sign bit
+        guard intB < 64 else {
+            return AST.RegoValue.number(NSNumber(value: intA >= 0 ? 0 : -1))
+        }
+
+        return AST.RegoValue.number(NSNumber(value: intA >> intB))
     }
 
     static func bitsNegate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {

--- a/Tests/RegoTests/BuiltinTests/BitsTests.swift
+++ b/Tests/RegoTests/BuiltinTests/BitsTests.swift
@@ -48,6 +48,12 @@ extension BuiltinTests.BitsTests {
             expected: .success(.number(NSNumber(value: 0)))
         ),
         BuiltinTests.TestCase(
+            description: "-1 << 70 (shift >= 64 returns 0)",
+            name: "bits.lsh",
+            args: [-1, 70],
+            expected: .success(.number(NSNumber(value: 0)))
+        ),
+        BuiltinTests.TestCase(
             description: "-255 << 2",
             name: "bits.lsh",
             args: [-255, 2],
@@ -103,6 +109,24 @@ extension BuiltinTests.BitsTests {
             name: "bits.rsh",
             args: [5, 33],
             expected: .success(.number(NSNumber(value: Int(5 >> 33))))
+        ),
+        BuiltinTests.TestCase(
+            description: "100 >> 64 (positive shift >= 64 returns 0)",
+            name: "bits.rsh",
+            args: [100, 64],
+            expected: .success(.number(NSNumber(value: 0)))
+        ),
+        BuiltinTests.TestCase(
+            description: "-100 >> 64 (negative shift >= 64 returns -1)",
+            name: "bits.rsh",
+            args: [-100, 64],
+            expected: .success(.number(NSNumber(value: -1)))
+        ),
+        BuiltinTests.TestCase(
+            description: "-100 >> 70 (negative shift >= 64 returns -1)",
+            name: "bits.rsh",
+            args: [-100, 70],
+            expected: .success(.number(NSNumber(value: -1)))
         ),
         BuiltinTests.TestCase(
             description: "-1020 >> 2",


### PR DESCRIPTION
Left and right shifts beyond 63 bits trapped.