### PR TITLE
builtins: Handle overflowing of parsed unit values.

### DIFF
--- a/Sources/Rego/Builtins/Units.swift
+++ b/Sources/Rego/Builtins/Units.swift
@@ -98,12 +98,12 @@ extension BuiltinFuncs {
         let result = NSNumber(value: NSDecimalNumber(decimal: u.apply(to: x)).doubleValue)
 
         // Handle infinite values that would crash in toNumberRegoValue
-        if !result.doubleValue.isFinite {
-            if returnInts {
-                return .number(NSNumber(value: result.doubleValue > 0 ? Int64.max : Int64.min))
-            } else {
-                return .number(NSNumber(value: result.doubleValue))
-            }
+        guard result.doubleValue.isFinite else {
+            let infiniteValue =
+                returnInts
+                ? NSNumber(value: result.doubleValue > 0 ? Int64.max : Int64.min)
+                : NSNumber(value: result.doubleValue)
+            return .number(infiniteValue)
         }
 
         return result.toNumberRegoValue(asInt: returnInts)

--- a/Sources/Rego/Builtins/Units.swift
+++ b/Sources/Rego/Builtins/Units.swift
@@ -96,6 +96,16 @@ extension BuiltinFuncs {
         // Note that if result *looks like an int*, we will just return an integer
         // even though we maintain our computations as Decimals
         let result = NSNumber(value: NSDecimalNumber(decimal: u.apply(to: x)).doubleValue)
+
+        // Handle infinite values that would crash in toNumberRegoValue
+        if !result.doubleValue.isFinite {
+            if returnInts {
+                return .number(NSNumber(value: result.doubleValue > 0 ? Int64.max : Int64.min))
+            } else {
+                return .number(NSNumber(value: result.doubleValue))
+            }
+        }
+
         return result.toNumberRegoValue(asInt: returnInts)
     }
 


### PR DESCRIPTION
NSDecimalNumber can express values larger than double. Avoids a trap.