### PR TITLE
builtins: Share builtins cache across builtin calls.

### DIFF
--- a/Sources/Rego/Evaluator.swift
+++ b/Sources/Rego/Evaluator.swift
@@ -17,6 +17,8 @@ internal struct EvaluationContext {
     public var strictBuiltins: Bool = false
     /// Date and Time of Context creation
     public let timestamp: Date
+    /// Shared cache for builtin function calls
+    public let builtinsCache: Ptr<BuiltinsCache>
 
     init(
         query: String,
@@ -34,6 +36,7 @@ internal struct EvaluationContext {
         self.tracer = tracer
         self.strictBuiltins = strictBuiltins
         self.timestamp = timestamp ?? Date()
+        self.builtinsCache = Ptr<BuiltinsCache>(toCopyOf: BuiltinsCache())
     }
 }
 

--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -951,6 +951,7 @@ private func evalCall(
     let bctx = BuiltinContext(
         location: try frame.v.currentLocation(withContext: ctx, stmt: caller),
         tracer: ctx.ctx.tracer,
+        cache: ctx.ctx.builtinsCache,
         timestamp: ctx.ctx.timestamp
     )
 


### PR DESCRIPTION
The benchmarks improve as follows:

Array Iteration - Large (1000 items): 1% faster execution, 25% less memory allocation
Array Iteration - Medium (100 items): 2% faster execution, 23% less memory allocation
Array Iteration - Small (10 items): 5% faster execution, 12% less memory allocation
Numeric Literals: 1% faster execution, 2% less memory allocation
Simple Policy Evaluation: 6% faster execution, no change in memory allocation
