### PR TITLE
perf: Per evaluation result set instance.

### DIFF
--- a/Sources/Rego/Evaluator.swift
+++ b/Sources/Rego/Evaluator.swift
@@ -46,9 +46,4 @@ extension ResultSet {
     public static var empty: ResultSet {
         return []
     }
-
-    /// Constructs a ResultSet containing a single value.
-    public init(value: AST.RegoValue) {
-        self = [value]
-    }
 }

--- a/Tests/RegoTests/IREvaluatorTests.swift
+++ b/Tests/RegoTests/IREvaluatorTests.swift
@@ -1141,8 +1141,7 @@ struct IRStatementTests {
         #expect(gotLocals == expectLocals, "comparing locals")
 
         let expectResult = tc.expectResult ?? .empty
-
-        #expect(results.results == expectResult, "comparing results")
+        #expect(ctx.results.v == expectResult, "comparing results")
 
         #expect(results.isUndefined == tc.expectUndefined, "comparing undefined")
     }


### PR DESCRIPTION
The benchmark result changes:

Array Iteration - Large (1000 items): 6% faster execution, 0% less memory allocation
Array Iteration - Medium (100 items): 5% faster execution, 1% less memory allocation
Array Iteration - Small (10 items): 5% faster execution, 3% less memory allocation
Numeric Literals: 3% faster execution, 0% less memory allocation
Simple Policy Evaluation: 11% faster execution, 5% less memory allocation