### PR TITLE
Benchmarks: record nanoseconds, not microseconds

### DIFF
--- a/Benchmarks/Sources/RegoBenchmarks.swift
+++ b/Benchmarks/Sources/RegoBenchmarks.swift
@@ -4,6 +4,8 @@ import Foundation
 internal import Rego
 
 let benchmarks: @Sendable () -> Void = {
+    Benchmark.defaultConfiguration.timeUnits = .nanoseconds
+
     let simpleBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/simple-directory-bundle")
     let dynamicCallBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/dynamic-call-bundle")
 


### PR DESCRIPTION
We don't currently use these numbers, so it should be OK to switch.

When using e.g. `swift package --allow-writing-to-package-directory benchmark --format histogramSamples`, we'll not get ns recordings. These make for a nice smooth CDF plot
<img width="989" height="483" alt="image" src="https://github.com/user-attachments/assets/ccbca93a-7041-45f6-9288-4c7e507e061f" />

Text output as of this change:
```
=====================================================================================================
Baseline 'Current_run'
=====================================================================================================

Host 'Mac.fritz.box' with 16 'arm64' processors with 64 GB memory, running:
Darwin Kernel Version 25.1.0: Mon Oct 20 19:34:05 PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T6041

==============
RegoBenchmarks
==============

Dynamic Call - Double
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Malloc (total) *         │       103 │       103 │       103 │       103 │       103 │       103 │       108 │      1767 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ns) * │     27834 │     28303 │     28543 │     30303 │     31839 │     56223 │     88416 │      1767 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

Dynamic Call - Square
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Malloc (total) *         │        59 │        59 │        59 │        59 │        59 │        59 │        62 │      1836 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ns) * │     14708 │     15007 │     15335 │     16543 │     17167 │     38815 │     42584 │      1836 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

Simple Policy Evaluation
╒══════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                   │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Malloc (total) *         │        42 │        42 │        42 │        42 │        42 │        42 │        43 │      1626 │
├──────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (ns) * │     13583 │     14087 │     15047 │     15503 │     16751 │     38015 │     41542 │      1626 │
╘══════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```