### PR TITLE
builtin: add object.union

### DIFF
--- a/Sources/Rego/Builtins/Objects.swift
+++ b/Sources/Rego/Builtins/Objects.swift
@@ -72,30 +72,35 @@ extension BuiltinFuncs {
         return .set(Set(x.keys))
     }
 
-    // union returns the merged result of the given input objects, the values from the second argument take precedence
-    // args - object1, object2
-    // returns: the merged result of object1 and object2
+    // union creates a new object of the asymmetric union of two objects.
+    // args
+    // a (object[any: any])
+    // left-hand object
+    // b (object[any: any])
+    // right-hand object
+    // returns: output (any) a new object which is the result of an asymmetric recursive union of two objects where conflicts 
+    // are resolved by choosing the key from the right-hand object b
     static func objectUnion(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
 
-        guard case .object(let object1) = args[0] else {
-            throw BuiltinError.argumentTypeMismatch(arg: "object1", got: args[0].typeName, want: "object")
+        guard case .object(let a) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "a", got: args[0].typeName, want: "object")
         }
 
-        guard case .object(let object2) = args[1] else {
-            throw BuiltinError.argumentTypeMismatch(arg: "object2", got: args[1].typeName, want: "object")
+        guard case .object(let b) = args[1] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "b", got: args[1].typeName, want: "object")
         }
 
-        guard !object1.isEmpty else {
-            return .object(object2)
+        guard !a.isEmpty else {
+            return .object(b)
         }
 
-        guard !object2.isEmpty else {
-            return .object(object1)
+        guard !b.isEmpty else {
+            return .object(a)
         }
 
-        return .object(object1.merging(object2) { (_, new) in new })
+        return .object(a.merging(b) { (_, new) in new })
     }
 }

--- a/Sources/Rego/Builtins/Objects.swift
+++ b/Sources/Rego/Builtins/Objects.swift
@@ -71,4 +71,31 @@ extension BuiltinFuncs {
 
         return .set(Set(x.keys))
     }
+
+    // union returns the merged result of the given input objects, the values from the second argument take precedence
+    // args - object1, object2
+    // returns: the merged result of object1 and object2
+    static func objectUnion(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 2 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
+        }
+
+        guard case .object(let object1) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "object1", got: args[0].typeName, want: "object")
+        }
+
+        guard case .object(let object2) = args[1] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "object2", got: args[1].typeName, want: "object")
+        }
+
+        guard !object1.isEmpty else {
+            return .object(object2)
+        }
+
+        guard !object2.isEmpty else {
+            return .object(object1)
+        }
+
+        return .object(object1.merging(object2) { (_, new) in new })
+    }
 }

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -113,6 +113,7 @@ public struct BuiltinRegistry: Sendable {
             // Objects
             "object.get": BuiltinFuncs.objectGet,
             "object.keys": BuiltinFuncs.objectKeys,
+            "object.union": BuiltinFuncs.objectUnion,
 
             // Sets
             "and": BuiltinFuncs.and,

--- a/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
+++ b/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
@@ -419,10 +419,137 @@ extension BuiltinTests.ObjectTests {
         ),
     ]
 
+    static let objectUnionTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "not enough args",
+            name: "object.union",
+            args: [],
+            expected: .failure(BuiltinError.argumentCountMismatch(got: 0, want: 2))
+        ),
+        BuiltinTests.TestCase(
+            description: "too many args",
+            name: "object.union",
+            args: [
+                [
+                    "a": 1,
+                    "b": 2,
+                ],
+                [
+                    "b": 1,
+                    "c": 2,
+                ],
+                [
+                    "b": 1,
+                    "c": 2,
+                ],
+            ],
+            expected: .failure(BuiltinError.argumentCountMismatch(got: 3, want: 2))
+        ),
+        BuiltinTests.TestCase(
+            description: "simple",
+            name: "object.union",
+            args: [
+                [
+                    "a": 1
+                ],
+                [
+                    "b": 1
+                ],
+            ],
+            expected: .success(.object(["a": 1, "b": 1]))
+        ),
+        BuiltinTests.TestCase(
+            description: "conflict resolution",
+            name: "object.union",
+            args: [
+                [
+                    "a": 1
+                ],
+                [
+                    "a": 2
+                ],
+            ],
+            expected: .success(.object(["a": 2]))
+        ),
+        BuiltinTests.TestCase(
+            description: "nested",
+            name: "object.union",
+            args: [
+                [
+                    "a": 1
+                ],
+                [
+                    "a": [
+                        "b": [
+                            "c": 1
+                        ]
+                    ],
+                    "d": 7,
+                ],
+            ],
+            expected: .success(.object(["a": ["b": ["c": 1]], "d": 7]))
+        ),
+        BuiltinTests.TestCase(
+            description: "both empty",
+            name: "object.union",
+            args: [
+                [:],
+                [:],
+            ],
+            expected: .success(.object([:]))
+        ),
+        BuiltinTests.TestCase(
+            description: "left empty",
+            name: "object.union",
+            args: [
+                [:],
+                ["a": 1],
+            ],
+            expected: .success(.object(["a": 1]))
+        ),
+        BuiltinTests.TestCase(
+            description: "right empty",
+            name: "object.union",
+            args: [
+                ["a": 1],
+                [:],
+            ],
+            expected: .success(.object(["a": 1]))
+        ),
+        BuiltinTests.TestCase(
+            description: "conflict multiple",
+            name: "object.union",
+            args: [
+                ["a": ["b": ["c": 1]], "e": 1],
+                ["a": ["b": "foo", "b1": "bar"], "d": 7, "e": 17],
+            ],
+            expected: .success(.object(["a": ["b": "foo", "b1": "bar"], "d": 7, "e": 17]))
+        ),
+        BuiltinTests.TestCase(
+            description: "wrong left type",
+            name: "object.union",
+            args: [
+                [],
+                ["a": 1],
+            ],
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "object1", got: "array", want: "object"))
+        ),
+        BuiltinTests.TestCase(
+            description: "wrong right type",
+            name: "object.union",
+            args: [
+                ["a": 1],
+                [],
+            ],
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "object2", got: "array", want: "object"))
+        ),
+    ]
+
     static var allTests: [BuiltinTests.TestCase] {
         [
             objectGetTests,
             objectKeysTests,
+            objectUnionTests,
         ].flatMap { $0 }
     }
 

--- a/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
+++ b/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
@@ -532,7 +532,7 @@ extension BuiltinTests.ObjectTests {
                 [],
                 ["a": 1],
             ],
-            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "object1", got: "array", want: "object"))
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "a", got: "array", want: "object"))
         ),
         BuiltinTests.TestCase(
             description: "wrong right type",
@@ -541,7 +541,7 @@ extension BuiltinTests.ObjectTests {
                 ["a": 1],
                 [],
             ],
-            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "object2", got: "array", want: "object"))
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "b", got: "array", want: "object"))
         ),
     ]
 


### PR DESCRIPTION
implements [object.union](https://www.openpolicyagent.org/docs/policy-reference/builtins/object#builtin-object-objectunion)

fixes 11 failing compliance tests