### PR TITLE
refactor: Replace Statement protocol with Statement enum to eliminate type-erasure.

### DIFF
--- a/Sources/IR/IR+StaticAnalysis.swift
+++ b/Sources/IR/IR+StaticAnalysis.swift
@@ -54,7 +54,7 @@ extension Block {
     }
 }
 
-extension AnyStatement {
+extension Statement {
     func computeMaxLocal() -> Int {
         var maxLocal = -1
 

--- a/Sources/IR/Statements.swift
+++ b/Sources/IR/Statements.swift
@@ -1,4 +1,4 @@
-public struct ArrayAppendStatement: Statement, Codable, Hashable {
+public struct ArrayAppendStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -10,7 +10,7 @@ public struct ArrayAppendStatement: Statement, Codable, Hashable {
     public var value: Operand
 }
 
-public struct AssignIntStatement: Statement, Codable, Hashable {
+public struct AssignIntStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -22,7 +22,7 @@ public struct AssignIntStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct AssignVarOnceStatement: Statement, Codable, Hashable {
+public struct AssignVarOnceStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -44,7 +44,7 @@ public struct AssignVarOnceStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct AssignVarStatement: Statement, Codable, Hashable {
+public struct AssignVarStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -66,7 +66,7 @@ public struct AssignVarStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct BlockStatement: Statement, Codable, Hashable {
+public struct BlockStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -80,7 +80,7 @@ public struct BlockStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct BreakStatement: Statement, Codable, Hashable {
+public struct BreakStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -94,7 +94,7 @@ public struct BreakStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct CallDynamicStatement: Statement, Codable, Hashable {
+public struct CallDynamicStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -108,7 +108,7 @@ public struct CallDynamicStatement: Statement, Codable, Hashable {
     public var result: Local
 }
 
-public struct CallStatement: Statement, Codable, Hashable {
+public struct CallStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     public var callFunc: String = ""
@@ -129,7 +129,7 @@ public struct CallStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct DotStatement: Statement, Codable, Hashable {
+public struct DotStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -149,7 +149,7 @@ public struct DotStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct EqualStatement: Statement, Codable, Hashable {
+public struct EqualStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -166,7 +166,7 @@ public struct EqualStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct IsArrayStatement: Statement, Codable, Hashable {
+public struct IsArrayStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -176,7 +176,7 @@ public struct IsArrayStatement: Statement, Codable, Hashable {
     public var source: Operand
 }
 
-public struct IsDefinedStatement: Statement, Codable, Hashable {
+public struct IsDefinedStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -187,7 +187,7 @@ public struct IsDefinedStatement: Statement, Codable, Hashable {
     public var source: Local
 }
 
-public struct IsObjectStatement: Statement, Codable, Hashable {
+public struct IsObjectStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -197,7 +197,7 @@ public struct IsObjectStatement: Statement, Codable, Hashable {
     public var source: Operand
 }
 
-public struct IsSetStatement: Statement, Codable, Hashable {
+public struct IsSetStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -207,7 +207,7 @@ public struct IsSetStatement: Statement, Codable, Hashable {
     public var source: Operand
 }
 
-public struct IsUndefinedStatement: Statement, Codable, Hashable {
+public struct IsUndefinedStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -222,7 +222,7 @@ public struct IsUndefinedStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct LenStatement: Statement, Codable, Hashable {
+public struct LenStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -239,7 +239,7 @@ public struct LenStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct MakeArrayStatement: Statement, Codable, Hashable {
+public struct MakeArrayStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -251,7 +251,7 @@ public struct MakeArrayStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct MakeNullStatement: Statement, Codable, Hashable {
+public struct MakeNullStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -261,7 +261,7 @@ public struct MakeNullStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct MakeNumberIntStatement: Statement, Codable, Hashable {
+public struct MakeNumberIntStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -273,7 +273,7 @@ public struct MakeNumberIntStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct MakeNumberRefStatement: Statement, Codable, Hashable {
+public struct MakeNumberRefStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -286,7 +286,7 @@ public struct MakeNumberRefStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct MakeObjectStatement: Statement, Codable, Hashable {
+public struct MakeObjectStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -303,7 +303,7 @@ public struct MakeObjectStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct MakeSetStatement: Statement, Codable, Hashable {
+public struct MakeSetStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -313,7 +313,7 @@ public struct MakeSetStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct NopStatement: Statement, Codable, Hashable {
+public struct NopStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     // Workaround - NopStatement has no fields aside from the Location fields, which
@@ -325,7 +325,7 @@ public struct NopStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct NotStatement: Statement, Codable, Hashable {
+public struct NotStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -335,7 +335,7 @@ public struct NotStatement: Statement, Codable, Hashable {
     public var block: Block
 }
 
-public struct NotEqualStatement: Statement, Codable, Hashable {
+public struct NotEqualStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -352,7 +352,7 @@ public struct NotEqualStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct ObjectInsertOnceStatement: Statement, Codable, Hashable {
+public struct ObjectInsertOnceStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -372,7 +372,7 @@ public struct ObjectInsertOnceStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct ObjectInsertStatement: Statement, Codable, Hashable {
+public struct ObjectInsertStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -395,7 +395,7 @@ public struct ObjectInsertStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct ObjectMergeStatement: Statement, Codable, Hashable {
+public struct ObjectMergeStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -409,7 +409,7 @@ public struct ObjectMergeStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct ResetLocalStatement: Statement, Codable, Hashable {
+public struct ResetLocalStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -419,7 +419,7 @@ public struct ResetLocalStatement: Statement, Codable, Hashable {
     public var target: Local
 }
 
-public struct ResultSetAddStatement: Statement, Codable, Hashable {
+public struct ResultSetAddStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -433,7 +433,7 @@ public struct ResultSetAddStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct ReturnLocalStatement: Statement, Codable, Hashable {
+public struct ReturnLocalStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -443,7 +443,7 @@ public struct ReturnLocalStatement: Statement, Codable, Hashable {
     public var source: Local
 }
 
-public struct ScanStatement: Statement, Codable, Hashable {
+public struct ScanStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -466,7 +466,7 @@ public struct ScanStatement: Statement, Codable, Hashable {
     }
 }
 
-public struct SetAddStatement: Statement, Codable, Hashable {
+public struct SetAddStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {
@@ -478,7 +478,7 @@ public struct SetAddStatement: Statement, Codable, Hashable {
     public var set: Local
 }
 
-public struct WithStatement: Statement, Codable, Hashable {
+public struct WithStatement: Sendable, Codable, Hashable {
     public var location: Location = Location()
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/IRTests/IRDecodeTests.swift
+++ b/Tests/IRTests/IRDecodeTests.swift
@@ -71,48 +71,53 @@ func decodeIRStatements() throws {
                             blocks: [
                                 Block(
                                     statements: [
-                                        CallStatement(
-                                            location: Location(row: 0, col: 8, file: 9),
-                                            callFunc: "g0.data.policy.hello",
-                                            args: [
-                                                Operand(
+                                        .callStmt(
+                                            CallStatement(
+                                                location: Location(row: 0, col: 8, file: 9),
+                                                callFunc: "g0.data.policy.hello",
+                                                args: [
+                                                    Operand(
+                                                        type: .local,
+                                                        value: .localIndex(0)
+                                                    ),
+                                                    Operand(
+                                                        type: .local,
+                                                        value: .localIndex(1)
+                                                    ),
+                                                ],
+                                                result: 2
+                                            )),
+                                        .assignVarStmt(
+                                            AssignVarStatement(
+                                                location: Location(row: 1, col: 2, file: 3),
+                                                source: Operand(
                                                     type: .local,
-                                                    value: .localIndex(0)
+                                                    value: .localIndex(2)
                                                 ),
-                                                Operand(
+                                                target: Local(3)
+                                            )),
+                                        .makeObjectStmt(
+                                            MakeObjectStatement(
+                                                location: Location(row: 0, col: 0, file: 0),
+                                                target: Local(4)
+                                            )),
+                                        .objectInsertStmt(
+                                            ObjectInsertStatement(
+                                                location: Location(row: 0, col: 0, file: 0),
+                                                key: Operand(
+                                                    type: .stringIndex,
+                                                    value: .stringIndex(0)
+                                                ),
+                                                value: Operand(
                                                     type: .local,
-                                                    value: .localIndex(1)
+                                                    value: .localIndex(3)
                                                 ),
-                                            ],
-                                            result: 2
-                                        ),
-                                        AssignVarStatement(
-                                            location: Location(row: 1, col: 2, file: 3),
-                                            source: Operand(
-                                                type: .local,
-                                                value: .localIndex(2)
-                                            ),
-                                            target: Local(3)
-                                        ),
-                                        MakeObjectStatement(
-                                            location: Location(row: 0, col: 0, file: 0),
-                                            target: Local(4)
-                                        ),
-                                        ObjectInsertStatement(
-                                            location: Location(row: 0, col: 0, file: 0),
-                                            key: Operand(
-                                                type: .stringIndex,
-                                                value: .stringIndex(0)
-                                            ),
-                                            value: Operand(
-                                                type: .local,
-                                                value: .localIndex(3)
-                                            ),
-                                            object: Local(4)
-                                        ),
-                                        ResultSetAddStatement(
-                                            value: Local(4)
-                                        ),
+                                                object: Local(4)
+                                            )),
+                                        .resultSetAddStmt(
+                                            ResultSetAddStatement(
+                                                value: Local(4)
+                                            )),
                                     ]
                                 )
                             ]
@@ -242,46 +247,50 @@ extension TestCaseCompareBlocks: CustomTestStringConvertible {
         name: "equal",
         lhs: Block(
             statements: [
-                CallStatement(
-                    location: Location(row: 0, col: 1, file: 2),
-                    callFunc: "myfunc",
-                    args: [
-                        Operand(
+                .callStmt(
+                    CallStatement(
+                        location: Location(row: 0, col: 1, file: 2),
+                        callFunc: "myfunc",
+                        args: [
+                            Operand(
+                                type: .local,
+                                value: .localIndex(789)
+                            )
+                        ],
+                        result: Local(7)
+                    )),
+                .assignVarStmt(
+                    AssignVarStatement(
+                        source: Operand(
                             type: .local,
-                            value: .localIndex(789)
-                        )
-                    ],
-                    result: Local(7)
-                ),
-                AssignVarStatement(
-                    source: Operand(
-                        type: .local,
-                        value: .localIndex(123)
-                    ),
-                    target: 456
-                ),
+                            value: .localIndex(123)
+                        ),
+                        target: 456
+                    )),
             ]
         ),
         rhs: Block(
             statements: [
-                CallStatement(
-                    location: Location(row: 0, col: 1, file: 2),
-                    callFunc: "myfunc",
-                    args: [
-                        Operand(
+                .callStmt(
+                    CallStatement(
+                        location: Location(row: 0, col: 1, file: 2),
+                        callFunc: "myfunc",
+                        args: [
+                            Operand(
+                                type: .local,
+                                value: .localIndex(789)
+                            )
+                        ],
+                        result: Local(7)
+                    )),
+                .assignVarStmt(
+                    AssignVarStatement(
+                        source: Operand(
                             type: .local,
-                            value: .localIndex(789)
-                        )
-                    ],
-                    result: Local(7)
-                ),
-                AssignVarStatement(
-                    source: Operand(
-                        type: .local,
-                        value: .localIndex(123)
-                    ),
-                    target: 456
-                ),
+                            value: .localIndex(123)
+                        ),
+                        target: 456
+                    )),
             ]
         ),
         expected: true
@@ -290,46 +299,50 @@ extension TestCaseCompareBlocks: CustomTestStringConvertible {
         name: "swapped not equal",
         lhs: Block(
             statements: [
-                AssignVarStatement(
-                    source: Operand(
-                        type: .local,
-                        value: .localIndex(123)
-                    ),
-                    target: 456
-                ),
-                CallStatement(
-                    location: Location(row: 0, col: 1, file: 2),
-                    callFunc: "myfunc",
-                    args: [
-                        Operand(
+                .assignVarStmt(
+                    AssignVarStatement(
+                        source: Operand(
                             type: .local,
-                            value: .localIndex(789)
-                        )
-                    ],
-                    result: Local(7)
-                ),
+                            value: .localIndex(123)
+                        ),
+                        target: 456
+                    )),
+                .callStmt(
+                    CallStatement(
+                        location: Location(row: 0, col: 1, file: 2),
+                        callFunc: "myfunc",
+                        args: [
+                            Operand(
+                                type: .local,
+                                value: .localIndex(789)
+                            )
+                        ],
+                        result: Local(7)
+                    )),
             ]
         ),
         rhs: Block(
             statements: [
-                CallStatement(
-                    location: Location(row: 0, col: 1, file: 2),
-                    callFunc: "myfunc",
-                    args: [
-                        Operand(
+                .callStmt(
+                    CallStatement(
+                        location: Location(row: 0, col: 1, file: 2),
+                        callFunc: "myfunc",
+                        args: [
+                            Operand(
+                                type: .local,
+                                value: .localIndex(789)
+                            )
+                        ],
+                        result: Local(7)
+                    )),
+                .assignVarStmt(
+                    AssignVarStatement(
+                        source: Operand(
                             type: .local,
-                            value: .localIndex(789)
-                        )
-                    ],
-                    result: Local(7)
-                ),
-                AssignVarStatement(
-                    source: Operand(
-                        type: .local,
-                        value: .localIndex(123)
-                    ),
-                    target: 456
-                ),
+                            value: .localIndex(123)
+                        ),
+                        target: 456
+                    )),
             ]
         ),
         expected: false
@@ -338,46 +351,50 @@ extension TestCaseCompareBlocks: CustomTestStringConvertible {
         name: "slightly different",
         lhs: Block(
             statements: [
-                CallStatement(
-                    location: Location(row: 0, col: 1, file: 2),
-                    callFunc: "myfunc",
-                    args: [
-                        Operand(
+                .callStmt(
+                    CallStatement(
+                        location: Location(row: 0, col: 1, file: 2),
+                        callFunc: "myfunc",
+                        args: [
+                            Operand(
+                                type: .local,
+                                value: .localIndex(789)
+                            )
+                        ],
+                        result: Local(7)
+                    )),
+                .assignVarStmt(
+                    AssignVarStatement(
+                        source: Operand(
                             type: .local,
-                            value: .localIndex(789)
-                        )
-                    ],
-                    result: Local(7)
-                ),
-                AssignVarStatement(
-                    source: Operand(
-                        type: .local,
-                        value: .localIndex(123)
-                    ),
-                    target: 456
-                ),
+                            value: .localIndex(123)
+                        ),
+                        target: 456
+                    )),
             ]
         ),
         rhs: Block(
             statements: [
-                CallStatement(
-                    location: Location(row: 0, col: 1, file: 2),
-                    callFunc: "myfunc",
-                    args: [
-                        Operand(
+                .callStmt(
+                    CallStatement(
+                        location: Location(row: 0, col: 1, file: 2),
+                        callFunc: "myfunc",
+                        args: [
+                            Operand(
+                                type: .local,
+                                value: .localIndex(790)
+                            )
+                        ],
+                        result: Local(7)
+                    )),
+                .assignVarStmt(
+                    AssignVarStatement(
+                        source: Operand(
                             type: .local,
-                            value: .localIndex(790)
-                        )
-                    ],
-                    result: Local(7)
-                ),
-                AssignVarStatement(
-                    source: Operand(
-                        type: .local,
-                        value: .localIndex(123)
-                    ),
-                    target: 456
-                ),
+                            value: .localIndex(123)
+                        ),
+                        target: 456
+                    )),
             ]
         ),
         expected: false

--- a/Tests/RegoTests/IREvaluatorTests.swift
+++ b/Tests/RegoTests/IREvaluatorTests.swift
@@ -271,7 +271,7 @@ struct IRStatementTests {
     struct TestCase {
         var description: String
         // stmt is the statement to evaluation
-        var stmt: any Statement
+        var stmt: Statement
         // locals are the input locals state
         var locals: Locals
         // If provided, expectLocals will be overlaid over locals and compared to the
@@ -289,7 +289,7 @@ struct IRStatementTests {
     }
 
     func prepareFrame(
-        forStatement stmt: any Statement,
+        forStatement stmt: Statement,
         withLocals locals: Locals,
         withFuncs funcs: [IR.Func] = [],
         withStaticStrings staticStrings: [String] = []
@@ -333,10 +333,11 @@ struct IRStatementTests {
     static let assignVarStmtTests: [TestCase] = [
         TestCase(
             description: "assign local",
-            stmt: IR.AssignVarStatement(
-                source: Operand(type: .local, value: .localIndex(0)),
-                target: Local(1)
-            ),
+            stmt: .assignVarStmt(
+                IR.AssignVarStatement(
+                    source: Operand(type: .local, value: .localIndex(0)),
+                    target: Local(1)
+                )),
             locals: [
                 0: ["some": "local"]
             ],
@@ -346,10 +347,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "assign local - source undefined",
-            stmt: IR.AssignVarStatement(
-                source: Operand(type: .local, value: .localIndex(42)),
-                target: Local(1)
-            ),
+            stmt: .assignVarStmt(
+                IR.AssignVarStatement(
+                    source: Operand(type: .local, value: .localIndex(42)),
+                    target: Local(1)
+                )),
             locals: [
                 0: "unrelated",
                 1: "will be overwritten",
@@ -360,10 +362,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "assign local - overwrite",
-            stmt: IR.AssignVarStatement(
-                source: Operand(type: .local, value: .localIndex(0)),
-                target: Local(1)
-            ),
+            stmt: .assignVarStmt(
+                IR.AssignVarStatement(
+                    source: Operand(type: .local, value: .localIndex(0)),
+                    target: Local(1)
+                )),
             locals: [
                 0: ["a", "b", "c"],
                 1: "will be overwritten",
@@ -374,10 +377,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "assign local - constant",
-            stmt: IR.AssignVarStatement(
-                source: Operand(type: .bool, value: .bool(true)),
-                target: Local(0)
-            ),
+            stmt: .assignVarStmt(
+                IR.AssignVarStatement(
+                    source: Operand(type: .bool, value: .bool(true)),
+                    target: Local(0)
+                )),
             locals: [:],
             expectLocals: [
                 0: true
@@ -385,10 +389,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "assign local - string ref",
-            stmt: IR.AssignVarStatement(
-                source: Operand(type: .stringIndex, value: .stringIndex(0)),
-                target: Local(0)
-            ),
+            stmt: .assignVarStmt(
+                IR.AssignVarStatement(
+                    source: Operand(type: .stringIndex, value: .stringIndex(0)),
+                    target: Local(0)
+                )),
             locals: [:],
             staticStrings: ["hello, world"],
             expectLocals: [
@@ -400,10 +405,11 @@ struct IRStatementTests {
     static let assignVarOnceStmtTests: [TestCase] = [
         TestCase(
             description: "initial assign local",
-            stmt: IR.AssignVarOnceStatement(
-                source: Operand(type: .local, value: .localIndex(0)),
-                target: Local(1)
-            ),
+            stmt: .assignVarOnceStmt(
+                IR.AssignVarOnceStatement(
+                    source: Operand(type: .local, value: .localIndex(0)),
+                    target: Local(1)
+                )),
             locals: [
                 0: "target value"
             ],
@@ -413,10 +419,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "assign local - source undefined",
-            stmt: IR.AssignVarOnceStatement(
-                source: Operand(type: .local, value: .localIndex(42)),
-                target: Local(1)
-            ),
+            stmt: .assignVarOnceStmt(
+                IR.AssignVarOnceStatement(
+                    source: Operand(type: .local, value: .localIndex(42)),
+                    target: Local(1)
+                )),
             locals: [
                 0: "unrelated"
             ],
@@ -426,10 +433,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "reassign string ref - same value allowed",
-            stmt: IR.AssignVarOnceStatement(
-                source: Operand(type: .stringIndex, value: .stringIndex(0)),
-                target: Local(1)
-            ),
+            stmt: .assignVarOnceStmt(
+                IR.AssignVarOnceStatement(
+                    source: Operand(type: .stringIndex, value: .stringIndex(0)),
+                    target: Local(1)
+                )),
             locals: [
                 1: "will be overwritten"
             ],
@@ -440,10 +448,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "reassign string ref - different value is an error",
-            stmt: IR.AssignVarOnceStatement(
-                source: Operand(type: .stringIndex, value: .stringIndex(0)),
-                target: Local(1)
-            ),
+            stmt: .assignVarOnceStmt(
+                IR.AssignVarOnceStatement(
+                    source: Operand(type: .stringIndex, value: .stringIndex(0)),
+                    target: Local(1)
+                )),
             locals: [
                 1: "initial value"
             ],
@@ -455,20 +464,21 @@ struct IRStatementTests {
     static let breakStmtTests: [TestCase] = [
         TestCase(
             description: "break makes the block undefined",
-            stmt: IR.BreakStatement(index: 0),
+            stmt: .breakStmt(IR.BreakStatement(index: 0)),
             locals: [:],
             expectUndefined: true
         ),
         TestCase(
             description: "breaking out of call frame is an error",
-            stmt: IR.CallStatement(
-                callFunc: "g0.f",
-                args: [
-                    Operand(type: .local, value: .localIndex(0)),
-                    Operand(type: .local, value: .localIndex(1)),
-                ],
-                result: Local(2)
-            ),
+            stmt: .callStmt(
+                IR.CallStatement(
+                    callFunc: "g0.f",
+                    args: [
+                        Operand(type: .local, value: .localIndex(0)),
+                        Operand(type: .local, value: .localIndex(1)),
+                    ],
+                    result: Local(2)
+                )),
             locals: [:],
             funcs: [
                 IR.Func(
@@ -481,7 +491,7 @@ struct IRStatementTests {
                     returnVar: Local(2),
                     blocks: [
                         IR.Block(statements: [
-                            IR.BreakStatement(index: 2)
+                            .breakStmt(IR.BreakStatement(index: 2))
                         ])
                     ]
                 )
@@ -493,14 +503,15 @@ struct IRStatementTests {
     static let callStmtTests: [TestCase] = [
         TestCase(
             description: "infinite recursion",
-            stmt: IR.CallStatement(
-                callFunc: "g0.f",
-                args: [
-                    Operand(type: .local, value: .localIndex(0)),
-                    Operand(type: .local, value: .localIndex(1)),
-                ],
-                result: Local(2)
-            ),
+            stmt: .callStmt(
+                IR.CallStatement(
+                    callFunc: "g0.f",
+                    args: [
+                        Operand(type: .local, value: .localIndex(0)),
+                        Operand(type: .local, value: .localIndex(1)),
+                    ],
+                    result: Local(2)
+                )),
             locals: [
                 0: [:],
                 1: [:],
@@ -516,14 +527,15 @@ struct IRStatementTests {
                     returnVar: Local(2),
                     blocks: [
                         IR.Block(statements: [
-                            IR.CallStatement(
-                                callFunc: "g0.f",
-                                args: [
-                                    Operand(type: .local, value: .localIndex(0)),
-                                    Operand(type: .local, value: .localIndex(1)),
-                                ],
-                                result: Local(2)
-                            )
+                            .callStmt(
+                                IR.CallStatement(
+                                    callFunc: "g0.f",
+                                    args: [
+                                        Operand(type: .local, value: .localIndex(0)),
+                                        Operand(type: .local, value: .localIndex(1)),
+                                    ],
+                                    result: Local(2)
+                                ))
                         ])
                     ]
                 )
@@ -535,10 +547,11 @@ struct IRStatementTests {
     static let lenStmtTests: [TestCase] = [
         TestCase(
             description: "len of empty array is 0",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: []
             ],
@@ -548,10 +561,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of non-empty array",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: [1, 2, 3, 4, 5]
             ],
@@ -561,10 +575,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of empty set",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: .set([])
             ],
@@ -574,10 +589,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of non-empty set",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: .set([1, 2])
             ],
@@ -587,10 +603,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of empty string",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: ""
             ],
@@ -600,10 +617,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of non-empty string",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: "hello, world"
             ],
@@ -613,10 +631,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of empty object",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: [:]
             ],
@@ -626,10 +645,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of non-empty object",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: ["foo": "bar", "baz": "qux"]
             ],
@@ -639,10 +659,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of unsupported type - integer",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: 42
             ],
@@ -650,10 +671,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of unsupported type - null",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: .null
             ],
@@ -661,10 +683,11 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "len of undefined is undefined",
-            stmt: IR.LenStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                target: Local(3)
-            ),
+            stmt: .lenStmt(
+                IR.LenStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
             locals: [
                 2: .undefined
             ],
@@ -676,11 +699,12 @@ struct IRStatementTests {
     static let objectInsertOnceStmtTests: [TestCase] = [
         TestCase(
             description: "first insert succeeds",
-            stmt: IR.ObjectInsertOnceStatement(
-                key: IR.Operand(type: .local, value: .localIndex(2)),
-                value: IR.Operand(type: .local, value: .localIndex(3)),
-                object: IR.Local(4)
-            ),
+            stmt: .objectInsertOnceStmt(
+                IR.ObjectInsertOnceStatement(
+                    key: IR.Operand(type: .local, value: .localIndex(2)),
+                    value: IR.Operand(type: .local, value: .localIndex(3)),
+                    object: IR.Local(4)
+                )),
             locals: [
                 2: "key",
                 3: "value",
@@ -692,11 +716,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "second insert with equal value succeeds",
-            stmt: IR.ObjectInsertOnceStatement(
-                key: IR.Operand(type: .local, value: .localIndex(2)),
-                value: IR.Operand(type: .local, value: .localIndex(3)),
-                object: IR.Local(4)
-            ),
+            stmt: .objectInsertOnceStmt(
+                IR.ObjectInsertOnceStatement(
+                    key: IR.Operand(type: .local, value: .localIndex(2)),
+                    value: IR.Operand(type: .local, value: .localIndex(3)),
+                    object: IR.Local(4)
+                )),
             locals: [
                 2: "key",
                 3: "prev_value",
@@ -708,11 +733,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "second insert with different values fails",
-            stmt: IR.ObjectInsertOnceStatement(
-                key: IR.Operand(type: .local, value: .localIndex(2)),
-                value: IR.Operand(type: .local, value: .localIndex(3)),
-                object: IR.Local(4)
-            ),
+            stmt: .objectInsertOnceStmt(
+                IR.ObjectInsertOnceStatement(
+                    key: IR.Operand(type: .local, value: .localIndex(2)),
+                    value: IR.Operand(type: .local, value: .localIndex(3)),
+                    object: IR.Local(4)
+                )),
             locals: [
                 2: "key",
                 3: "new_value",
@@ -722,11 +748,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "target is not an object",
-            stmt: IR.ObjectInsertOnceStatement(
-                key: IR.Operand(type: .local, value: .localIndex(2)),
-                value: IR.Operand(type: .local, value: .localIndex(3)),
-                object: IR.Local(4)
-            ),
+            stmt: .objectInsertOnceStmt(
+                IR.ObjectInsertOnceStatement(
+                    key: IR.Operand(type: .local, value: .localIndex(2)),
+                    value: IR.Operand(type: .local, value: .localIndex(3)),
+                    object: IR.Local(4)
+                )),
             locals: [
                 2: "key",
                 3: "new_value",
@@ -736,11 +763,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "key is undefined",
-            stmt: IR.ObjectInsertOnceStatement(
-                key: IR.Operand(type: .local, value: .localIndex(2)),
-                value: IR.Operand(type: .local, value: .localIndex(3)),
-                object: IR.Local(4)
-            ),
+            stmt: .objectInsertOnceStmt(
+                IR.ObjectInsertOnceStatement(
+                    key: IR.Operand(type: .local, value: .localIndex(2)),
+                    value: IR.Operand(type: .local, value: .localIndex(3)),
+                    object: IR.Local(4)
+                )),
             locals: [
                 3: "new_value",
                 4: [:],
@@ -751,11 +779,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "value is undefined",
-            stmt: IR.ObjectInsertOnceStatement(
-                key: IR.Operand(type: .local, value: .localIndex(2)),
-                value: IR.Operand(type: .local, value: .localIndex(3)),
-                object: IR.Local(4)
-            ),
+            stmt: .objectInsertOnceStmt(
+                IR.ObjectInsertOnceStatement(
+                    key: IR.Operand(type: .local, value: .localIndex(2)),
+                    value: IR.Operand(type: .local, value: .localIndex(3)),
+                    object: IR.Local(4)
+                )),
             locals: [
                 2: "key",
                 4: [:],
@@ -768,11 +797,12 @@ struct IRStatementTests {
     static let dotStmtTests: [TestCase] = [
         TestCase(
             description: "in-bounds array lookup",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: ["a", "b", "c"],
                 3: 1,
@@ -783,11 +813,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "out-of-bounds array lookup is undefined",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: [0, 1, 2],
                 3: 3,
@@ -798,11 +829,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "negative out-of-bounds array lookup is undefined",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: [0, 1, 2],
                 3: -1,
@@ -813,11 +845,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "object lookup",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: ["a": "z"],
                 3: "a",
@@ -828,11 +861,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "object lookup - key not found",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: ["a": "z"],
                 3: "b",
@@ -843,11 +877,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "set lookup",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: .set(["x", "y"]),
                 3: "x",
@@ -858,11 +893,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "set lookup - not found",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: .set(["x", "y"]),
                 3: "z",
@@ -873,11 +909,12 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "unsupported type lookup - undefined",
-            stmt: IR.DotStatement(
-                source: IR.Operand(type: .local, value: .localIndex(2)),
-                key: IR.Operand(type: .local, value: .localIndex(3)),
-                target: Local(4)
-            ),
+            stmt: .dotStmt(
+                IR.DotStatement(
+                    source: IR.Operand(type: .local, value: .localIndex(2)),
+                    key: IR.Operand(type: .local, value: .localIndex(3)),
+                    target: Local(4)
+                )),
             locals: [
                 2: "double rainbow",
                 3: "what does it mean??",
@@ -891,12 +928,13 @@ struct IRStatementTests {
     static let scanStmtTests: [TestCase] = [
         TestCase(
             description: "source undefined",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [])
-            ),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [])
+                )),
             locals: [
                 2: .undefined
             ],
@@ -906,15 +944,16 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "scalar - undefined",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    // Copy value into resultset
-                    ResultSetAddStatement(value: Local(4))
-                ])
-            ),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        // Copy value into resultset
+                        .resultSetAddStmt(ResultSetAddStatement(value: Local(4)))
+                    ])
+                )),
             locals: [
                 // Can only scan collections
                 2: "not a collection"
@@ -925,22 +964,25 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "empty array",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    // if any (key == value)
-                    EqualStatement(
-                        a: IR.Operand(type: .local, value: .localIndex(3)),
-                        b: IR.Operand(type: .local, value: .localIndex(4))
-                    ),
-                    AssignVarStatement(
-                        source: IR.Operand(type: .bool, value: .bool(true)),
-                        target: Local(5)
-                    ),
-                ])
-            ),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        // if any (key == value)
+                        .equalStmt(
+                            EqualStatement(
+                                a: IR.Operand(type: .local, value: .localIndex(3)),
+                                b: IR.Operand(type: .local, value: .localIndex(4))
+                            )),
+                        .assignVarStmt(
+                            AssignVarStatement(
+                                source: IR.Operand(type: .bool, value: .bool(true)),
+                                target: Local(5)
+                            )),
+                    ])
+                )),
             locals: [
                 2: []
             ],
@@ -948,22 +990,25 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "array - some iterations were truthy",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    // if any (key == value)
-                    EqualStatement(
-                        a: IR.Operand(type: .local, value: .localIndex(3)),
-                        b: IR.Operand(type: .local, value: .localIndex(4))
-                    ),
-                    AssignVarStatement(
-                        source: IR.Operand(type: .bool, value: .bool(true)),
-                        target: Local(5)
-                    ),
-                ])
-            ),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        // if any (key == value)
+                        .equalStmt(
+                            EqualStatement(
+                                a: IR.Operand(type: .local, value: .localIndex(3)),
+                                b: IR.Operand(type: .local, value: .localIndex(4))
+                            )),
+                        .assignVarStmt(
+                            AssignVarStatement(
+                                source: IR.Operand(type: .bool, value: .bool(true)),
+                                target: Local(5)
+                            )),
+                    ])
+                )),
             locals: [
                 2: [9, 1, 8]
             ],
@@ -977,22 +1022,25 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "array - none were truthy",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    // if any (key == value)
-                    EqualStatement(
-                        a: IR.Operand(type: .local, value: .localIndex(3)),
-                        b: IR.Operand(type: .local, value: .localIndex(4))
-                    ),
-                    AssignVarStatement(
-                        source: IR.Operand(type: .bool, value: .bool(true)),
-                        target: Local(5)
-                    ),
-                ])
-            ),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        // if any (key == value)
+                        .equalStmt(
+                            EqualStatement(
+                                a: IR.Operand(type: .local, value: .localIndex(3)),
+                                b: IR.Operand(type: .local, value: .localIndex(4))
+                            )),
+                        .assignVarStmt(
+                            AssignVarStatement(
+                                source: IR.Operand(type: .bool, value: .bool(true)),
+                                target: Local(5)
+                            )),
+                    ])
+                )),
             locals: [
                 2: [9, 9, 9]
             ],
@@ -1005,23 +1053,25 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "object - copy key/values into results",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    BlockStatement(blocks: [
-                        Block(statements: [
-                            // Copy key into resultset
-                            ResultSetAddStatement(value: Local(3))
-                        ]),
-                        Block(statements: [
-                            // Copy value into resultset
-                            ResultSetAddStatement(value: Local(4))
-                        ]),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        .blockStmt(
+                            BlockStatement(blocks: [
+                                Block(statements: [
+                                    // Copy key into resultset
+                                    .resultSetAddStmt(ResultSetAddStatement(value: Local(3)))
+                                ]),
+                                Block(statements: [
+                                    // Copy value into resultset
+                                    .resultSetAddStmt(ResultSetAddStatement(value: Local(4)))
+                                ]),
+                            ]))
                     ])
-                ])
-            ),
+                )),
             locals: [
                 2: [
                     "a": 1,
@@ -1035,23 +1085,25 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "object - empty",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    BlockStatement(blocks: [
-                        Block(statements: [
-                            // Copy key into resultset
-                            ResultSetAddStatement(value: Local(3))
-                        ]),
-                        Block(statements: [
-                            // Copy value into resultset
-                            ResultSetAddStatement(value: Local(4))
-                        ]),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        .blockStmt(
+                            BlockStatement(blocks: [
+                                Block(statements: [
+                                    // Copy key into resultset
+                                    .resultSetAddStmt(ResultSetAddStatement(value: Local(3)))
+                                ]),
+                                Block(statements: [
+                                    // Copy value into resultset
+                                    .resultSetAddStmt(ResultSetAddStatement(value: Local(4)))
+                                ]),
+                            ]))
                     ])
-                ])
-            ),
+                )),
             locals: [
                 // Empty object, so no iterations
                 2: [:]
@@ -1061,15 +1113,16 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "set - copy values into result",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    // Copy value into resultset
-                    ResultSetAddStatement(value: Local(4))
-                ])
-            ),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        // Copy value into resultset
+                        .resultSetAddStmt(ResultSetAddStatement(value: Local(4)))
+                    ])
+                )),
             locals: [
                 // Empty set, so no iterations
                 2: .set(["a", "b", "c"])
@@ -1080,15 +1133,16 @@ struct IRStatementTests {
         ),
         TestCase(
             description: "set - empty",
-            stmt: IR.ScanStatement(
-                source: Local(2),
-                key: Local(3),
-                value: Local(4),
-                block: Block(statements: [
-                    // Copy value into resultset
-                    ResultSetAddStatement(value: Local(4))
-                ])
-            ),
+            stmt: .scanStmt(
+                IR.ScanStatement(
+                    source: Local(2),
+                    key: Local(3),
+                    value: Local(4),
+                    block: Block(statements: [
+                        // Copy value into resultset
+                        .resultSetAddStmt(ResultSetAddStatement(value: Local(4)))
+                    ])
+                )),
             locals: [
                 // Empty set, so no iterations
                 2: .set([])
@@ -1109,7 +1163,7 @@ struct IRStatementTests {
         )
         let block = IR.Block(statements: [tc.stmt])
 
-        let caller = IR.AnyStatement.blockStmt(IR.BlockStatement(blocks: [block]))
+        let caller = IR.Statement.blockStmt(IR.BlockStatement(blocks: [block]))
         let result = await Result {
             try await evalBlock(withContext: ctx, framePtr: frame, caller: caller, block: block)
         }
@@ -1134,7 +1188,7 @@ struct IRStatementTests {
         }
 
         // Use resize for scan statements to chop off the scan block's locals
-        if tc.stmt is IR.ScanStatement {
+        if case .scanStmt = tc.stmt {
             gotLocals.resize(to: expectLocals.count)
         }
 


### PR DESCRIPTION
Renames AnyStatement to Statement and updates all statement usage to wrap concrete types in enum cases.