### PR TITLE
perf: Pre-parse numeric literals and pre-verify string indices

### DIFF
--- a/Sources/IR/IR+Decode.swift
+++ b/Sources/IR/IR+Decode.swift
@@ -9,12 +9,12 @@ extension Policy {
     public init(jsonData rawJson: Data) throws {
         self = try JSONDecoder().decode(Self.self, from: rawJson)
 
-        self.prepareForExecution()
+        try self.prepareForExecution()
     }
 
     /// Prepare the policy for execution by running static analysis passes.
     /// This computes properties like maxLocal that are used for optimization.
-    public mutating func prepareForExecution() {
+    public mutating func prepareForExecution() throws {
         // Compute maxLocal for all plans
         if var plans = self.plans {
             for i in plans.plans.indices {
@@ -33,5 +33,28 @@ extension Policy {
             }
             self.funcs = funcs
         }
+
+        try self.verifyStaticStrings()
+        self.identifyStaticStringNumbers()
+    }
+
+    /// Identify which static string indices are used for numeric literals.
+    /// This allows IndexedIRPolicy to pre-parse only the strings that are actually numbers.
+    mutating func identifyStaticStringNumbers() {
+        var indices = Set<Int>()
+
+        if let plans = self.plans {
+            for plan in plans.plans {
+                plan.identifyStaticStringNumbers(into: &indices)
+            }
+        }
+
+        if let funcList = self.funcs?.funcs {
+            for function in funcList {
+                function.identifyStaticStringNumbers(into: &indices)
+            }
+        }
+
+        self.staticStringNumbers = Array(indices).sorted()
     }
 }

--- a/Sources/IR/IR.swift
+++ b/Sources/IR/IR.swift
@@ -6,6 +6,10 @@ public struct Policy: Codable, Hashable, Sendable {
     public var plans: Plans? = nil
     public var funcs: Funcs? = nil
 
+    // Computed during static analysis: which static string indices are numeric literals
+    // (i.e., referenced by MakeNumberRefStmt)
+    public var staticStringNumbers: [Int] = []
+
     public init(staticData: Static? = nil, plans: Plans? = nil, funcs: Funcs? = nil) {
         self.staticData = staticData
         self.plans = plans
@@ -16,6 +20,7 @@ public struct Policy: Codable, Hashable, Sendable {
         case staticData = "static"
         case plans
         case funcs
+        // staticStringNumbers not encoded - computed during prepareForExecution
     }
 }
 

--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -186,7 +186,7 @@ extension OPA.Engine {
                 throw RegoError.init(code: .invalidArgumentError, message: "Cannot mix direct IR policies with bundles")
             }
 
-            evaluator = IREvaluator(policies: self.policies)
+            evaluator = try IREvaluator(policies: self.policies)
         } else {
             evaluator = try IREvaluator(bundles: loadedBundles)
         }

--- a/Tests/RegoTests/IREvaluatorTests.swift
+++ b/Tests/RegoTests/IREvaluatorTests.swift
@@ -293,12 +293,12 @@ struct IRStatementTests {
         withLocals locals: Locals,
         withFuncs funcs: [IR.Func] = [],
         withStaticStrings staticStrings: [String] = []
-    )
+    ) throws
         -> IREvaluationContext
     {
         let block = Block(statements: [stmt])
 
-        let policy = IndexedIRPolicy(
+        let policy = try IndexedIRPolicy(
             policy: IR.Policy(
                 staticData: IR.Static(
                     strings: staticStrings.map { IR.ConstString(value: $0) }
@@ -1154,7 +1154,7 @@ struct IRStatementTests {
 
     @Test(arguments: allTests)
     func testStatementEvaluation(tc: TestCase) async throws {
-        let ctx = prepareFrame(
+        let ctx = try prepareFrame(
             forStatement: tc.stmt,
             withLocals: tc.locals,
             withFuncs: tc.funcs,


### PR DESCRIPTION
Introduces a generic IR walker to eliminate code duplication across static analysis passes. Uses it to implement:
    
* Number pre-parsing: parse numeric literals during IR loading to eliminate runtime NumberFormatter calls in MakeNumberRefStmt.
    
* String index verification: validate static string indices during IR loading.

In average benchmarks see ~10% performance improvement (w/ up to 25% less allocations) but numeric literal benchmarks is up to 67% faster and 52% less allocations.