### PR TITLE
rework MemoStack back into a separate type

### DIFF
--- a/Sources/Rego/Memo.swift
+++ b/Sources/Rego/Memo.swift
@@ -15,7 +15,7 @@ struct InvocationKey: Hashable {
 typealias MemoCache = [InvocationKey: AST.RegoValue]
 
 /// MemoStack is a stack of MemoCaches
-struct MemoStack {
+final class MemoStack {
     var stack: [MemoCache] = []
 }
 
@@ -36,11 +36,11 @@ extension MemoStack {
         }
     }
 
-    mutating func push() {
+    func push() {
         self.stack.append(MemoCache.init())
     }
 
-    mutating func pop() {
+    func pop() {
         guard !self.stack.isEmpty else {
             return
         }
@@ -50,7 +50,7 @@ extension MemoStack {
     /// withPush returns the result of calling the provided closure with
     /// a fresh memoCache pushed on the stack. The memoCache will only be
     /// active during that call, and discarded when it completes.
-    mutating func withPush<T>(_ body: () async throws -> T) async rethrows -> T {
+    func withPush<T>(_ body: () async throws -> T) async rethrows -> T {
         self.push()
         defer {
             self.pop()

--- a/Sources/Rego/Memo.swift
+++ b/Sources/Rego/Memo.swift
@@ -1,0 +1,60 @@
+import AST
+import Foundation
+import IR
+
+/// InvocationKey is a key for memoizing an IR function call invocation.
+/// Note we capture the arguments as unresolved operands and not resolved values,
+/// as hashing the values was proving extremely expensive. We instead rely on the
+/// invariant the the plan / evaluator will not modify a local after it has been initally set.
+struct InvocationKey: Hashable {
+    let funcName: String
+    let args: [IR.Operand]
+}
+
+/// MemoCache is a memoization cache of plan invocations
+typealias MemoCache = [InvocationKey: AST.RegoValue]
+
+/// MemoStack is a stack of MemoCaches
+struct MemoStack {
+    var stack: [MemoCache] = []
+}
+
+extension MemoStack {
+    /// Get and set values on the cache at the top of the memo stack.
+    subscript(key: InvocationKey) -> AST.RegoValue? {
+        get {
+            guard !self.stack.isEmpty else {
+                return nil
+            }
+            return self.stack[self.stack.count - 1][key]
+        }
+        set {
+            if self.stack.isEmpty {
+                self.stack.append(MemoCache.init())
+            }
+            self.stack[self.stack.count - 1][key] = newValue
+        }
+    }
+
+    mutating func push() {
+        self.stack.append(MemoCache.init())
+    }
+
+    mutating func pop() {
+        guard !self.stack.isEmpty else {
+            return
+        }
+        self.stack.removeLast()
+    }
+
+    /// withPush returns the result of calling the provided closure with
+    /// a fresh memoCache pushed on the stack. The memoCache will only be
+    /// active during that call, and discarded when it completes.
+    mutating func withPush<T>(_ body: () async throws -> T) async rethrows -> T {
+        self.push()
+        defer {
+            self.pop()
+        }
+        return try await body()
+    }
+}


### PR DESCRIPTION
https://github.com/open-policy-agent/swift-opa/pull/59 was a bit aggressive in flattening the MemoStack functionality into the IREvaluationContext. This led to unclear division of responsibility and APIs - for example having the subscript operator of IREvaluationContext dereference the memo stack is surprising.

This commit works part of that back by separating the MemoStack into its previously distinct type. This should not impact the performance gains of #59, as a lot of that was likely due to removal of the Frame functionality.