### PR TITLE
perf: Do not check for task cancellation before each statement

### DIFF
--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -459,7 +459,7 @@ func evalBlock(
     stmtLoop: for i in block.statements.indices {
         let statement = block.statements[i]
 
-        if Task.isCancelled {
+        if i % 16 == 0 && Task.isCancelled {
             throw RegoError(code: .evaluationCancelled, message: "parent task cancelled")
         }
 


### PR DESCRIPTION
Periodic cancellation checking (every 16 statements) delivers 8-9% speedup on larger workloads and 1-3% on smaller ones.