### PR TITLE
perf: Locals and args pooling

### DIFF
--- a/Sources/Rego/Locals.swift
+++ b/Sources/Rego/Locals.swift
@@ -83,6 +83,16 @@ internal struct Locals: Equatable, Sendable, Encodable {
     var count: Int { storage.count }
     var isEmpty: Bool { storage.isEmpty }
 
+    // Clear values up to usedCount and return the storage for pooling
+    mutating func releaseStorage(usedCount: Int? = nil) -> [AST.RegoValue?] {
+        let clearCount = usedCount ?? storage.count
+        for i in 0..<clearCount {
+            storage[i] = nil
+        }
+
+        return storage
+    }
+
     // Resize array to specific size, truncating or extending with nil as needed
     mutating func resize(to size: Int) {
         guard size >= 0 else {


### PR DESCRIPTION
Pool size is bounded by max call depth, ensuring allocations scale with recursion depth not total function invocations.

Pooling optimization helps significantly with non-trivial policies (which involve iteration and function calls), but introduces minor overhead with trivial policies where the work is already cheap. Up to 10% faster with iteration heavy evaluations due to most allocations removed and a couple percent slower with non-iterative, trivial workloads (due to minor increase in allocs).