### PR TITLE
builtins: rand.intn

### DIFF
--- a/Sources/Rego/Builtins/Rand.swift
+++ b/Sources/Rego/Builtins/Rand.swift
@@ -1,0 +1,43 @@
+import AST
+import Foundation
+
+private let randNamespace: String = "rand"
+
+extension BuiltinFuncs {
+    static func numbersRandIntN(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 2 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
+        }
+
+        guard case .string(let str) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "str", got: args[0].typeName, want: "string")
+        }
+
+        guard case .number(_) = args[1] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "n", got: args[1].typeName, want: "number")
+        }
+
+        // NOTE that we are okay with argument n being a float with integer value,
+        // i.e. rand.intn("key", 100.0) is okay
+        guard let n = args[1].integerValue else {
+            throw BuiltinError.evalError(msg: "operand 1 must be integer number but got floating-point number")
+        }
+
+        let key: String = "\(str)-\(n)"
+        let existing: RegoValue? = ctx.cache.v[key, .namespace(randNamespace)]
+        guard let existing else {
+            var value: UInt64 = 0
+
+            if n != 0 {
+                value = UInt64(UInt64.random(in: 0..<UInt64(Swift.abs(n)), using: &ctx.rand.v))
+            }
+
+            let result = RegoValue.number(NSNumber(value: value))
+            ctx.cache.v[key, .namespace(randNamespace)] = result
+
+            return result
+        }
+
+        return existing
+    }
+}

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -185,10 +185,6 @@ public struct BuiltinRegistry: Sendable {
         self.builtins[name]
     }
 
-    init(builtins: [String: Builtin]) {
-        self.builtins = builtins
-    }
-
     func invoke(
         withContext ctx: BuiltinContext,
         name: String,

--- a/Tests/RegoTests/BuiltinTests/RandTests.swift
+++ b/Tests/RegoTests/BuiltinTests/RandTests.swift
@@ -1,0 +1,113 @@
+import AST
+import Foundation
+import Testing
+
+@testable import Rego
+
+extension BuiltinTests {
+    @Suite("BuiltinTests - Rand", .tags(.builtins))
+    struct RandTests {}
+}
+
+extension BuiltinTests.RandTests {
+    static let randTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "with n=0",
+            name: "rand.intn",
+            args: ["key", 0],
+            expected: .success(0)
+        ),
+
+        BuiltinTests.TestCase(
+            description: "with n is not an integer",
+            name: "rand.intn",
+            args: ["key", 100.1],
+            expected: .failure(
+                BuiltinError.evalError(
+                    msg: "operand 1 must be integer number but got floating-point number"))
+        ),
+    ]
+
+    static var allTests: [BuiltinTests.TestCase] {
+        [
+            randTests,
+            BuiltinTests.generateFailureTests(
+                builtinName: "rand.intn", sampleArgs: ["key", 10], argIndex: 0,
+                argName: "str", allowedArgTypes: ["string"], generateNumberOfArgsTest: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "rand.intn", sampleArgs: ["key", 10], argIndex: 1,
+                argName: "n", allowedArgTypes: ["number"], generateNumberOfArgsTest: false),
+        ].flatMap { $0 }
+    }
+
+    @Test(arguments: allTests)
+    func testBuiltins(tc: BuiltinTests.TestCase) async throws {
+        try await BuiltinTests.testBuiltin(tc: tc)
+    }
+
+    static let boundaries: [Int64] = [
+        Int64(Int32.min) - 10, -5_647_870, -500, 0, 10, Int64(Int32.max), Int64(Int32.max) + 10,
+    ]
+
+    @Test("rand.intn returns correct value for n=", arguments: boundaries)
+    func randIntNReturnsCorrectValue(n: Int64) async throws {
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext()
+        let result = try await reg.invoke(
+            withContext: ctx, name: "rand.intn",
+            args: ["foo", .number(n as NSNumber)], strict: true)
+        switch result {
+        case .number(let value):
+            #expect(!result.isFloat, "expect result to be an integer")
+
+            let intValue = value.uint64Value
+
+            // Make sure the returned value is within correct bounds.
+            if n != 0 {
+                #expect(intValue >= 0 && intValue < Swift.abs(n), "expect result to be within bound of \(n)")
+            } else {
+                #expect(intValue == 0, "expect result to 0 for n=0")
+            }
+        default:
+            Issue.record("rand.intn with n=\(n) should return an integer, but got: \(result)")
+        }
+    }
+
+    @Test
+    func randIntNReturnsSameValueForSameInputs() async throws {
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext()
+        let result1 = try await reg.invoke(withContext: ctx, name: "rand.intn", args: ["foo", 1000], strict: true)
+        let result2 = try await reg.invoke(withContext: ctx, name: "rand.intn", args: ["foo", 1000], strict: true)
+        #expect(result1 == result2)
+    }
+
+    @Test
+    func randIntNReturnsDifferentValueForDifferentBounds() async throws {
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext()
+        let result1 = try await reg.invoke(withContext: ctx, name: "rand.intn", args: ["foo", 1], strict: true)
+        // Using large n avoids having two random numbers match in practice via two sequential calls
+        // to SystemRandomNumberGenerator which will be used by ctx
+        let result2 = try await reg.invoke(
+            withContext: ctx, name: "rand.intn", args: ["foo", 10_000_000],
+            strict: true)
+
+        #expect(result1 != result2)
+    }
+
+    @Test
+    func randIntNReturnsDifferentValuesForDifferentKeys() async throws {
+        let reg = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext()
+        // Using large n avoids having two random numbers match in practice via two sequential calls
+        // to SystemRandomNumberGenerator which will be used by ctx
+        let result1 = try await reg.invoke(
+            withContext: ctx, name: "rand.intn", args: ["foo", 10_000_000],
+            strict: true)
+        let result2 = try await reg.invoke(
+            withContext: ctx, name: "rand.intn", args: ["bar", 10_000_000],
+            strict: true)
+        #expect(result1 != result2)
+    }
+}


### PR DESCRIPTION
Rebased #39 with a lint fix. I figured it's the quickest way to get this in.

Verified that it's working as expected with the value cached:

```
$ swift run swift-opa-cli eval data.p.r --bundle b0 
[1/1] Planning build
Building for debugging...
[1/1] Write swift-version--58304C5D6DBC2206.txt
Build of product 'swift-opa-cli' complete! (0.82s)
[
  {
    "result" : [
      95
    ]
  }
]
```
Where bundle contained this rego:

```rego
package p

r contains rand.intn("foo", 100) if true
r contains rand.intn("foo", 100) if true
r contains rand.intn("foo", 100) if true
```

Resolves #38
