### PR TITLE
builtins: add `strings.count`

### DIFF
--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -145,6 +145,7 @@ public struct BuiltinRegistry: Sendable {
             "split": BuiltinFuncs.split,
             "sprintf": BuiltinFuncs.sprintf,
             "startswith": BuiltinFuncs.startsWith,
+            "strings.count": BuiltinFuncs.stringsCount,
             "strings.reverse": BuiltinFuncs.reverse,
             "substring": BuiltinFuncs.substring,
             "trim": BuiltinFuncs.trim,

--- a/Sources/Rego/Builtins/Strings.swift
+++ b/Sources/Rego/Builtins/Strings.swift
@@ -62,6 +62,28 @@ extension BuiltinFuncs {
         return .boolean(haystack.contains(needle))
     }
 
+    static func stringsCount(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 2 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
+        }
+
+        guard case .string(let search) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "search", got: args[0].typeName, want: "string")
+        }
+
+        guard case .string(let substring) = args[1] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "substring", got: args[1].typeName, want: "string")
+        }
+
+        // Handle empty substring case - should return 0 per OPA behavior
+        guard !substring.isEmpty else {
+            return .number(0)
+        }
+
+        let occurrences = search.allRanges(of: substring).count
+        return .number(NSNumber(value: occurrences))
+    }
+
     static func endsWith(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)

--- a/Tests/RegoTests/BuiltinTests/StringsTests.swift
+++ b/Tests/RegoTests/BuiltinTests/StringsTests.swift
@@ -1129,6 +1129,13 @@ extension BuiltinTests.StringsTests {
             interpolationTests,
 
             BuiltinTests.generateFailureTests(
+                builtinName: "strings.count", sampleArgs: ["search", "substring"], argIndex: 0,
+                argName: "search", allowedArgTypes: ["string"], generateNumberOfArgsTest: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "strings.count", sampleArgs: ["search", "substring"], argIndex: 1,
+                argName: "substring", allowedArgTypes: ["string"], generateNumberOfArgsTest: false),
+
+            BuiltinTests.generateFailureTests(
                 builtinName: "startswith", sampleArgs: ["a", "b"], argIndex: 0, argName: "search",
                 allowedArgTypes: ["string"], generateNumberOfArgsTest: true),
             BuiltinTests.generateFailureTests(


### PR DESCRIPTION
I've only added arg-type-mismatch test cases, since the actual functionality is asserted by the compliance tests' JSON cases.