### PR TITLE
builtins: add `object.union_n`

### DIFF
--- a/Sources/Rego/Builtins/Objects.swift
+++ b/Sources/Rego/Builtins/Objects.swift
@@ -103,4 +103,32 @@ extension BuiltinFuncs {
 
         return .object(a.merging(b) { (_, new) in new })
     }
+
+    // union_n creates a new object by merging all objects in the provided array of objects to merge (array[object[any: any]])
+    // returns: output (any) a new object which is the result of an asymmetric recursive union of all objects
+    // where conflicts are resolved by choosing the key from the right-hand object
+    static func objectUnionN(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+
+        guard case .array(let objects) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "objects", got: args[0].typeName, want: "array")
+        }
+
+        // Start with an empty object as the accumulator
+        var result: [AST.RegoValue: AST.RegoValue] = [:]
+
+        // Iterate through each object in the array
+        for (index, obj) in objects.enumerated() {
+            guard case .object(let objDict) = obj else {
+                throw BuiltinError.argumentTypeMismatch(arg: "objects[\(index)]", got: obj.typeName, want: "object")
+            }
+
+            // Merge this object into the result (right-hand side wins on conflicts)
+            result = result.merging(objDict) { (_, new) in new }
+        }
+
+        return .object(result)
+    }
 }

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -122,6 +122,7 @@ public struct BuiltinRegistry: Sendable {
             "object.get": BuiltinFuncs.objectGet,
             "object.keys": BuiltinFuncs.objectKeys,
             "object.union": BuiltinFuncs.objectUnion,
+            "object.union_n": BuiltinFuncs.objectUnionN,
 
             // Rand
             "rand.intn": BuiltinFuncs.numbersRandIntN,

--- a/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
+++ b/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
@@ -545,11 +545,55 @@ extension BuiltinTests.ObjectTests {
         ),
     ]
 
+    static let objectUnionNTests: [BuiltinTests.TestCase] = [
+        // Argument validation tests (not covered by JSON-based compliance tests)
+        BuiltinTests.TestCase(
+            description: "not enough args",
+            name: "object.union_n",
+            args: [],
+            expected: .failure(BuiltinError.argumentCountMismatch(got: 0, want: 1))
+        ),
+        BuiltinTests.TestCase(
+            description: "too many args",
+            name: "object.union_n",
+            args: [
+                .array([["a": 1]]),
+                .array([["b": 2]]),
+            ],
+            expected: .failure(BuiltinError.argumentCountMismatch(got: 2, want: 1))
+        ),
+        BuiltinTests.TestCase(
+            description: "wrong arg type",
+            name: "object.union_n",
+            args: [
+                ["a": 1]
+            ],
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "objects", got: "object", want: "array"))
+        ),
+        BuiltinTests.TestCase(
+            description: "wrong array element type",
+            name: "object.union_n",
+            args: [
+                .array([["a": 1], "not an object"])
+            ],
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "objects[1]", got: "string", want: "object"))
+        ),
+        BuiltinTests.TestCase(
+            description: "mixed valid and invalid array elements",
+            name: "object.union_n",
+            args: [
+                .array([["a": 1], .null, ["c": 3]])
+            ],
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "objects[1]", got: "null", want: "object"))
+        ),
+    ]
+
     static var allTests: [BuiltinTests.TestCase] {
         [
             objectGetTests,
             objectKeysTests,
             objectUnionTests,
+            objectUnionNTests,
         ].flatMap { $0 }
     }
 


### PR DESCRIPTION
Again only adding tests not already covered by the compliance-tests.