### PR TITLE
ci: Add build matrix for Swift 6.0.3 - 6.2.3

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,19 +12,51 @@ concurrency:
 
 jobs:
   ci:
-    name: 'make all'
+    name: Build Swift ${{ matrix.swift }}, Xcode ${{ matrix.xcode }}
     runs-on: macos-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode: "16.2"
+            swift: "6.0.3"
+          - xcode: "16.4"
+            swift: "6.1" # We can't go more modern than 6.1.0 for the 6.1 runner, due to Xcode version support.
+          - xcode: "26.2"
+            swift: "6.2.3"
+    env:
+      XCODE_VERSION: ${{ matrix.xcode }}
+      DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
+      SWIFT_VERSION: ${{ matrix.swift }}
     steps:
-      - run: sudo xcode-select -s /Applications/Xcode_26.0.app
-      - run: swift --version
+      - name: Select Xcode version
+        run: |
+          sudo xcode-select --switch "${DEVELOPER_DIR}/Contents/Developer"
+          xcodebuild -version
+      - name: Show Swift version
+        run: swift --version
+      - name: Fail if Swift version does not match expected version (${{ matrix.swift }})
+        run: |
+          SWIFT_OUTPUT=$(swift --version)
+          echo "${SWIFT_OUTPUT}"
+          # Check if our expected Swift version is the one in use.
+          if ! echo "${SWIFT_OUTPUT}" | grep -q "${SWIFT_VERSION}"; then
+            ACTUAL=$(echo "${SWIFT_OUTPUT}" | head -n 1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n 1)
+            echo "::error::Expected Swift ${SWIFT_VERSION}, got ${ACTUAL}"
+            echo "**Version Mismatch**: Expected \`${SWIFT_VERSION}\`, got \`${ACTUAL}\`" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install jemalloc
         run: brew install jemalloc
-      - run: make lint
-      - run: make test
-      - run: make build
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test
+      - name: Build
+        run: make build
       - name: make fmt lint test (ComplianceSuite)
         run: make fmt lint test
         working-directory: ComplianceSuite

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Swift-OPA
 
+[![Swift 6.0.3+](https://img.shields.io/badge/Swift-6.0.3+-blue.svg)](https://developer.apple.com/swift/)
+
 Swift-OPA is a Swift package for evaluating [OPA IR
 Plans](https://www.openpolicyagent.org/docs/latest/ir/) compiled from
 [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/#what-is-rego)


### PR DESCRIPTION
## What changed?

This PR adds basic support for building and testing the project against each Swift major version (patched) from Swift 6.0, up to Swift 6.2.

This allows us to ensure we support older language versions and toolchains for projects that can't upgrade immediately.

This PR also adds a basic shields.io badge to the README, to indicate our minimum supported version:
[![Swift 6.0.3+](https://img.shields.io/badge/Swift-6.0.3+-blue.svg)](https://developer.apple.com/swift/)

## How to test

Like most GH Actions changes, the only way to test if a workflow works is to test it live. ~~This PR will stay in "Draft" state, until I've ensured it actually works as intended.~~

Testing for this PR should be as simple as pushing up a commit and observing the build matrix complete successfully (or not!) for each major language version.

- Success cases:
  - Do we get a green build for each matrix target? (EDIT: ✅ The project builds on all three versions now!)
- Failure cases:
  - Can we introduce a compile issue on a commit and see build failures? (EDIT: ✅ Yep! I reintroduced a 6.0.3-specific issue on a commit, and the 6.0.3 build target exploded.)
  - If the Swift version is wrong, can we detect it and error? (EDIT: ✅ Yep. Added a step that asserts the version is what we think it is.)

## Further Reading
 - `macOS-15` runner image Xcode version support matrix: https://github.com/actions/runner-images/issues/12520
 - `macOS-15` picked up Xcode 26.2: https://github.com/actions/runner-images/pull/13444
 - List of Swift version ↔️ Xcode version mappings: https://swiftversion.net/