### PR TITLE
ci: Add Github Release automation.

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -1,0 +1,54 @@
+name: Post Tag
+
+# This workflow contains our release automation.
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    name: Release Build (macos-latest)
+    runs-on: macos-latest
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_26.0.app"
+      SWIFT_VERSION: 6.2.3
+    steps:
+      - name: Select Xcode version
+        run: |
+          sudo xcode-select --switch "${DEVELOPER_DIR}/Contents/Developer"
+          xcodebuild -version
+      - name: Show Swift version
+        run: swift --version
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Install jemalloc
+        run: brew install jemalloc
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test
+      - name: Build
+        run: make build
+
+  gh-release-notes:
+    name: Release Notes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Set TAG_NAME in Environment
+        # Subsequent jobs will be have the computed tag name
+        run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Create or Update Release
+        env:
+          # Required for the GitHub CLI
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./tools/build/github-release.sh --tag=${TAG_NAME}

--- a/.github/workflows/pr-release-check.yaml
+++ b/.github/workflows/pr-release-check.yaml
@@ -1,0 +1,104 @@
+name: Release Check
+
+# This workflow is isolated into its own file, because it requires
+# elevated pull_request_target permissions. Any executable code
+# or scripts here should depend only on trusted code in main, and
+# not on anything from the PR.
+on:
+  workflow_dispatch: {}
+  pull_request_target: {}
+
+# When a new revision is pushed to a PR, cancel all in-progress CI runs for that
+# PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-check:
+    name: Release version check
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6.0.1
+        with:
+          ref: ${{ github.base_ref }}  # Use scripts only from trusted base branch
+          fetch-depth: 0  # Fetch full history to access all commits
+
+      - name: Fetch PR from fork
+        run: |
+          # Don't allow user to provide branch name. Bind to PR number ref explicitly.
+          git fetch origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
+
+      - name: Check for release commits
+        id: check-release
+        run: |
+          RESULT=$(./tools/build/get-release-from-commits.sh "origin/${{ github.base_ref }}" "pr-head")
+          echo "Release commits detected: $RESULT"
+          if [ -n "$RESULT" ]; then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+  
+      - name: Get CHANGELOG version from PR
+        if: steps.check-release.outputs.result == 'true'
+        id: changelog
+        run: |
+          # Checkout just the CHANGELOG from PR
+          git show "pr-head:CHANGELOG.md" > /tmp/changelog-pr.md
+          CHANGELOG_VERSION=$(grep -o -E '## [0-9.]+' /tmp/changelog-pr.md | head -n 1 | sed 's/## //' | grep -E '^[0-9.]+$' || echo "invalid")
+          echo "version=$CHANGELOG_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update warning comment (release commit detected)
+        if: steps.check-release.outputs.result == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: "<!-- release-commit-warning -->"
+        run: |
+          COMMIT_VERSION=$(./tools/build/get-release-from-commits.sh "origin/${{ github.base_ref }}" "pr-head")
+          CHANGELOG_VERSION="${{ steps.changelog.outputs.version }}"
+
+          COMMENT=$(mktemp)
+          echo "ℹ️ **Release Commit Detected**"                                                        >> "$COMMENT"
+          echo ""                                                                                      >> "$COMMENT"
+          echo "This PR contains commit(s) that match the case-insensitive regex \`^Release .*\`"      >> "$COMMENT"
+          echo ""                                                                                      >> "$COMMENT"
+          echo "Here are the latest versions reported from the places the release workflows will use:" >> "$COMMENT"
+          echo ""                                                                                      >> "$COMMENT"
+          echo "| Source | Version |"                                                                  >> "$COMMENT"
+          echo "| --- | --- |"                                                                         >> "$COMMENT"
+          echo "| Commit matching \`^Release .*\` | $COMMIT_VERSION |"                                 >> "$COMMENT"
+          echo "| \`CHANGELOG.md\` | $CHANGELOG_VERSION |"                                             >> "$COMMENT"
+
+          echo "Posting or updating release warning comment."
+          export COMMENT_BODY="$(cat "$COMMENT")"
+          ./tools/build/release-pr-comment.sh "$REPO" "$PR_NUMBER" "$MARKER"
+
+      - name: Update warning comment if present (no release commit)
+        if: steps.check-release.outputs.result != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MARKER: "<!-- release-commit-warning -->"
+          COMMENT_BODY: |
+            ℹ️ A release commit was detected in earlier versions of this PR.
+
+            The current PR commits do not appear to be a release.
+        run: |
+          EXISTING_COMMENT=$(gh api repos/$REPO/issues/$PR_NUMBER/comments \
+              --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1) || {
+              echo "Error: Failed to fetch existing comments" >&2
+              exit 2
+          }
+
+          if [ -n "$EXISTING_COMMENT" ]; then
+            echo "Updating release warning comment."
+            ./tools/build/release-pr-comment.sh "$REPO" "$PR_NUMBER" "$MARKER"
+          else
+            echo "No release warning comment found."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. This
+project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+
+## 0.0.1
+
+This release is a release engineering experiment, designed to test out our Github Release automation.
+
+In future release notes, we will discuss significant change to the project since the last release.
+Thank you for reading!
+

--- a/tools/build/get-release-from-commits.sh
+++ b/tools/build/get-release-from-commits.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Script to extract version from release commits for GH Actions checks.
+# Note: Remember to include the "origin/" prefix for remote branches!
+#  Otherwise, checks will be done against local branches of matching names.
+# Usage: get-release-from-commits.sh <base_branch> <head_branch> [pattern]
+
+set -x
+set -e  # Exit on any error
+
+# Check args.
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+    echo "Usage: $0 <base_branch> <head_branch> [pattern]"
+    echo ""
+    echo "Arguments:"
+    echo "  base_branch    Base branch to compare against"
+    echo "  head_branch    Head branch to check"
+    echo "  pattern        Pattern to search for (default: '^Release [v]?[0-9.]+')"
+    echo ""
+    echo "Output: '<version>' if release commits found, '' otherwise"
+    echo ""
+    echo "Example (local branch): $0 origin/main user/feature"
+    echo "Example (remote branch): $0 origin/main origin/user/feature"
+    exit 1
+fi
+
+BASE_BRANCH="$1"
+HEAD_BRANCH="$2"
+PATTERN="${3:-^Release v?[0-9.]+}"
+
+# Check if we're in a git repository.
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "Error: Not in a git repository" >&2
+    exit 2
+fi
+
+# Get commit messages from the range.
+COMMITS=$(git log --oneline $BASE_BRANCH..$HEAD_BRANCH --pretty=format:"%s" 2>/dev/null) || {
+    echo "Error: Failed to get commit messages. Check if branches exist." >&2
+    exit 2
+}
+
+# If no commits, return empty.
+if [ -z "$COMMITS" ]; then
+    exit 0
+fi
+
+# Check for release pattern and extract version.
+VERSION=$(echo "$COMMITS" | grep -E -i "$PATTERN" | head -n 1 | grep -E -o '[0-9.]+') || {
+    echo "No matches found."
+    exit 0
+}
+
+if [ -n "$VERSION" ]; then
+    echo "$VERSION"
+fi

--- a/tools/build/github-release.sh
+++ b/tools/build/github-release.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Script to draft and edit Swift OPA GitHub releases. Assumes execution environment is Github Actions runner.
+
+set -x
+
+usage() {
+    echo "github-release.sh  [--tag=<git tag>]"
+    echo "    Default --tag is $TAG_NAME "
+}
+
+TAG_NAME=${TAG_NAME}
+
+for i in "$@"; do
+    case $i in
+    --tag=*)
+        TAG_NAME="${i#*=}"
+        shift
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+# Gather the release notes from the CHANGELOG for the latest version
+RELEASE_NOTES="release-notes.md"
+
+# The hub CLI expects the first line to be the title
+echo -e "${TAG_NAME}\n" > "${RELEASE_NOTES}"
+
+# Fill in the description
+./build/latest-release-notes.sh --output="${RELEASE_NOTES}"
+
+# Update or create a release on github
+if gh release view "${TAG_NAME}" --repo open-policy-agent/swift-opa > /dev/null; then
+    # Occurs when the tag is created via GitHub UI w/ a release
+    gh release upload "${TAG_NAME}" --repo open-policy-agent/swift-opa
+else
+    # Create a draft release
+    gh release create "${TAG_NAME}" -F ${RELEASE_NOTES} --draft --title "${TAG_NAME}" --repo open-policy-agent/swift-opa
+fi

--- a/tools/build/latest-release-notes.sh
+++ b/tools/build/latest-release-notes.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -e
+
+PROJ_DIR=$(dirname "${BASH_SOURCE}")/..
+CHANGELOG="${PROJ_DIR}/CHANGELOG.md"
+
+usage() {
+    echo "latest-release-notes.sh --output=<path>"
+}
+
+OUTPUT=""
+
+for i in "$@"; do
+    case $i in
+    --output=*)
+        OUTPUT="${i#*=}"
+        shift
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "${OUTPUT}" ]; then
+    usage
+    exit 1
+fi
+
+# Versions start with a h2 (## <semver>), find the latest two for start and stop
+# positions in the CHANGELOG
+LATEST_VERSION=$(grep '## [0-9]' "${CHANGELOG}" | head -n 1)
+STOP_VERSION=$(grep '## [0-9]' "${CHANGELOG}" | head -n 2 | tail -n 1)
+
+STARTED=false
+
+while IFS= read -r line
+do
+    # Skip lines until the first version header is found
+    if [[ "${STARTED}" == false ]]; then
+        if [[ "${line}" == "${LATEST_VERSION}" ]]; then
+            STARTED=true
+        fi
+        continue
+    fi
+
+    # Stop reading after we see the stopping point
+    if [[ "${line}" == "${STOP_VERSION}" ]]; then
+        break
+    fi
+
+    # Append each line between the two onto the release notes
+    echo -e "${line}" >> "${OUTPUT}"
+
+done < "${CHANGELOG}"
+
+# Delete all leading blank lines at top of file
+sed -i.bak '/./,$!d' "${OUTPUT}"
+rm "${OUTPUT}.bak"

--- a/tools/build/release-pr-comment.sh
+++ b/tools/build/release-pr-comment.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Script to create or update a PR comment with a unique marker
+# Usage: release-pr-comment.sh <repo> <pr_number> [marker]
+
+set -e  # Exit on any error
+
+# Check arguments
+if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+    echo "Usage: $0 <repo> <pr_number> [marker]"
+    echo "   or: echo 'comment body' | $0 <repo> <pr_number> [marker]"
+    echo "   or: COMMENT_BODY='comment body' $0 <repo> <pr_number> [marker]"
+    echo ""
+    echo "Arguments:"
+    echo "  repo           Repository in format 'owner/repo'"
+    echo "  pr_number      Pull request number"
+    echo "  marker         Unique HTML comment marker (default: '<!-- auto-comment -->')"
+    echo ""
+    echo "Comment body source (in order of precedence):"
+    echo "  1. COMMENT_BODY environment variable"
+    echo "  2. stdin (if not a terminal)"
+    echo ""
+    echo "Environment variables:"
+    echo "  COMMENT_BODY   Comment body text (optional)"
+    echo "  GH_TOKEN       GitHub token for authentication"
+    echo ""
+    echo "The script will update existing comments with the same marker or create a new one."
+    exit 1
+fi
+
+REPO="$1"
+PR_NUMBER="$2"
+MARKER="${3:-<!-- auto-comment -->}"
+
+echo "DEBUG: $COMMENT_BODY"
+
+# Get comment body from environment variable or stdin
+if [ -n "$COMMENT_BODY" ]; then
+    echo "Using comment body from COMMENT_BODY environment variable" >&2
+elif [ ! -t 0 ]; then
+    # stdin is not a terminal (has data piped to it)
+    echo "Reading comment body from stdin" >&2
+    COMMENT_BODY=$(cat)
+else
+    echo "Error: No comment body provided. Set COMMENT_BODY environment variable or pipe content to stdin." >&2
+    exit 1
+fi
+
+# Check if comment body is empty
+if [ -z "$COMMENT_BODY" ]; then
+    echo "Error: Comment body is empty" >&2
+    exit 1
+fi
+
+# Check if gh CLI is available
+if ! command -v gh &> /dev/null; then
+    echo "Error: gh CLI is not available" >&2
+    exit 2
+fi
+
+# Check if GH_TOKEN is set (gh CLI will handle the actual auth)
+if [ -z "$GH_TOKEN" ]; then
+    echo "Warning: GH_TOKEN environment variable not set" >&2
+fi
+
+# Add marker and timestamp to comment body
+TIMESTAMPED_BODY="$MARKER
+$COMMENT_BODY
+
+_Last updated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')_"
+
+# Look for existing comment with our marker
+echo "Checking for existing comment with marker..." >&2
+EXISTING_COMMENT=$(gh api repos/$REPO/issues/$PR_NUMBER/comments \
+    --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1) || {
+    echo "Error: Failed to fetch existing comments" >&2
+    exit 2
+}
+
+if [ -n "$EXISTING_COMMENT" ]; then
+    echo "Updating existing comment ID: $EXISTING_COMMENT" >&2
+    gh api repos/$REPO/issues/comments/$EXISTING_COMMENT \
+        --method PATCH \
+        --field body="$TIMESTAMPED_BODY" || {
+        echo "Error: Failed to update comment" >&2
+        exit 2
+    }
+    echo "Comment updated successfully" >&2
+else
+    echo "Creating new comment" >&2
+    gh api repos/$REPO/issues/$PR_NUMBER/comments \
+        --method POST \
+        --field body="$TIMESTAMPED_BODY" || {
+        echo "Error: Failed to create comment" >&2
+        exit 2
+    }
+    echo "Comment created successfully" >&2
+fi


### PR DESCRIPTION
## What changed?

This PR adds a basic Github Actions workflow for creating Github Releases with release notes pulled from the project's `CHANGELOG.md` every time a tag is pushed.

The automation here is based on the OPA project's release setup, where a PR with updated release notes is merged, and then tagged. Once the tag is pushed, the workflow runs that creates a draft Github Release.

Also included is a "release commit check" job from the OPA C# SDK, which helps maintainers make sure they bumped the version numbers consistently for each release. In our case, the only two places we need to check should be just the release commit header and the CHANGELOG.

The release commit check job requires elevated permissions ([`pull_request_target`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target)) to be able to take write actions against the host repo, while checking out code in a PR from a fork. In my previous uses of the release-check job, branches were always repo-local, bypassing the security restrictions fork branches have to deal with. The new version of the release-check workflow will not run correctly until it is merged, due to requiring elevated permissions. Once the file exists on `main`, it can run on future PRs.

## How to test?

 - Like most GH Actions PRs, the truest test will be merging and running this PR.
   - We will need a follow-up PR after this one to make sure the release checks work as intended. Logs from earlier Actions runs suggest the scripts are working properly, it's just the PR comment posting that is broken, due to permissions.
 - To test the release notes generation, from the base folder of the project, run the script that extracts the latest release notes: `./tools/build/latest-release-notes.sh --output=RESULT.md`
 - ~~To test the release commit checks, we'll need to push up a fake release commit or two to make sure the scripts are reading from the right places, and that the workflow is behaving correctly.~~

## Further reading

 - OPA's release workflow: https://github.com/open-policy-agent/opa/blob/main/.github/workflows/post-tag.yaml
 - OPA C# SDK's Release PR check system: https://github.com/open-policy-agent/opa-csharp/blob/779663eef8f50650c5182191d517a1ee4e07ca93/.github/workflows/pull-request.yaml#L34-L90
