### PR TITLE
ci: Fix issue in release detection script.

### DIFF
--- a/tools/build/get-release-from-commits.sh
+++ b/tools/build/get-release-from-commits.sh
@@ -46,7 +46,7 @@ fi
 
 # Check for release pattern and extract version.
 VERSION=$(echo "$COMMITS" | grep -E -i "$PATTERN" | head -n 1 | grep -E -o '[0-9.]+') || {
-    echo "No matches found."
+    echo "No matches found." >&2
     exit 0
 }
 


### PR DESCRIPTION
## What changed?

This commit fixes an issue where even when no release was detected, the release checks workflow would still fire. This was caused by an informational message being dumped to stdout instead of stderr.