### PR TITLE
ci: Fix missing checkout step for post-tag workflow.

### DIFF
--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -46,7 +46,11 @@ jobs:
       - name: Set TAG_NAME in Environment
         # Subsequent jobs will be have the computed tag name
         run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Create or Update Release
         env:
           # Required for the GitHub CLI


### PR DESCRIPTION
## What changed?

This commit fixes a missing repo checkout needed by one of the post-tag release workflows. This should allow our Github release scripts to run, and create draft releases for each tag.

We'll cut the 0.0.2 release right after this, and if all goes well, that one should be able to auto-draft a Github release for us!