### PR TITLE
ci: add Linux test runs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,29 +12,41 @@ concurrency:
 
 jobs:
   ci:
-    name: Build Swift ${{ matrix.swift }}, Xcode ${{ matrix.xcode }}
-    runs-on: macos-latest
+    name: Build Swift ${{ matrix.swift }}${{ matrix.xcode && format(', Xcode {0}', matrix.xcode) || '' }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
         include:
-          - xcode: "16.2"
+          - os: macos-latest
+            xcode: "16.2"
             swift: "6.0.3"
-          - xcode: "16.4"
+          - os: macos-latest
+            xcode: "16.4"
             swift: "6.1" # We can't go more modern than 6.1.0 for the 6.1 runner, due to Xcode version support.
-          - xcode: "26.2"
+          - os: macos-latest
+            xcode: "26.2"
             swift: "6.2.3"
+          - os: ubuntu-latest
+            swift: "6.0.3"
+          - os: ubuntu-latest
+            swift: "6.2"
     env:
       XCODE_VERSION: ${{ matrix.xcode }}
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
       SWIFT_VERSION: ${{ matrix.swift }}
     steps:
       - name: Select Xcode version
+        if: runner.os == 'macOS'
         run: |
           sudo xcode-select --switch "${DEVELOPER_DIR}/Contents/Developer"
           xcodebuild -version
+      - uses: swift-actions/setup-swift@v2
+        if: runner.os == 'Linux'
+        with:
+          swift-version: ${{ matrix.swift }}
       - name: Show Swift version
         run: swift --version
       - name: Fail if Swift version does not match expected version (${{ matrix.swift }})
@@ -50,6 +62,7 @@ jobs:
           fi
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install jemalloc
+        if: runner.os == 'macOS'
         run: brew install jemalloc
       - name: Lint
         run: make lint

--- a/Sources/AST/RegoNumber.swift
+++ b/Sources/AST/RegoNumber.swift
@@ -281,7 +281,12 @@ extension RegoNumber {
 
     /// Create RegoNumber from NSNumber (for number parsing - assumes non-boolean NSNumber)
     public init(nsNumber: NSNumber) {
-        let nsNumberIsFloatType = CFNumberIsFloatType(nsNumber as CFNumber)
+        #if canImport(Darwin)
+            let nsNumberIsFloatType = CFNumberIsFloatType(nsNumber as CFNumber)
+        #else
+            let objCType = String(cString: nsNumber.objCType)
+            let nsNumberIsFloatType = objCType.contains("f") || objCType.contains("d")
+        #endif
 
         if !nsNumberIsFloatType {
             let nsInt64Value = nsNumber.int64Value

--- a/Tests/ASTTests/RegoValue+CodableTests.swift
+++ b/Tests/ASTTests/RegoValue+CodableTests.swift
@@ -106,6 +106,18 @@ struct RegoValueEncodingTests {
         TestCase(description: "2.998e8->exploded", value: .number(RegoNumber(value: 2.998e8)), expected: "299800000"),
     ]
 
+    static let knownLinuxIssues: Set<String> = [
+        "3.141592657"
+    ]
+
+    private var isLinux: Bool {
+        #if os(Linux)
+            true
+        #else
+            false
+        #endif
+    }
+
     @Test(arguments: floatEncodingTests)
     func testEncodeFloat(tc: TestCase) throws {
         guard !tc.expectError else {
@@ -114,8 +126,14 @@ struct RegoValueEncodingTests {
             }
             return
         }
-        let encoded = try String(tc.value)
-        #expect(encoded == tc.expected)
+        try withKnownIssue(isIntermittent: true) {
+            let encoded = try String(tc.value)
+            #expect(encoded == tc.expected)
+        } when: {
+            isLinux
+        } matching: { _ in
+            RegoValueEncodingTests.knownLinuxIssues.contains(tc.description)
+        }
     }
 
     @Test

--- a/Tests/RegoTests/BuiltinTests/ArithmeticTests.swift
+++ b/Tests/RegoTests/BuiltinTests/ArithmeticTests.swift
@@ -17,15 +17,12 @@ extension BuiltinTests.ArithmeticTests {
             args: [1, 1],
             expected: .success(2)
         ),
-        // TODO: Uh oh, we've got floating point comparison and math problems
-        // we might need to do something like what OPA does upstream using strings
-        // and "big" number libraries to achieve similar behaviors (and consistency)
-        //BuiltinTests.TestCase(
-        //    description: "1 + 1.234567890",
-        //    name: "plus",
-        //    args: [1, 1.234567890],
-        //    expected: .success(2.23456789)
-        //),
+        BuiltinTests.TestCase(
+            description: "1 + 1.234567890",
+            name: "plus",
+            args: [1, 1.234567890],
+            expected: .success(2.23456789)
+        ),
         BuiltinTests.TestCase(
             description: "1.33333 + 1.33333",
             name: "plus",
@@ -78,7 +75,7 @@ extension BuiltinTests.ArithmeticTests {
             expected: .success(0.76543211)
         ),
         BuiltinTests.TestCase(
-            description: "2.33333 + 1.33333",
+            description: "2.33333 - 1.33333",
             name: "minus",
             args: [2.33333, 1.33333],
             expected: .success(1)
@@ -480,8 +477,9 @@ extension BuiltinTests.ArithmeticTests {
     }
 
     static let knownIssues: Set<String> = [
+        "plus: 1 + 1.234567890",
         "minus: 2 - 1.234567890",
-        "minus: 2.33333 + 1.33333",
+        "minus: 2.33333 - 1.33333",
         "mul: overflow",
     ]
 


### PR DESCRIPTION
This doesn't pass all tests because we haven't sorted out number precision on Linux. For now at least, we can run all the other tests, and the failing ones have been recorded.

Also un-comments an existing test that passes since #51 (probably!)