### PR TITLE
builtins: Add `walk` builtin.

### DIFF
--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -180,6 +180,9 @@ public struct BuiltinRegistry: Sendable {
             // UUID
             "uuid.rfc4122": BuiltinFuncs.makeRfc4122UUID,
             "uuid.parse": BuiltinFuncs.parseUUID,
+
+            // Walk
+            "walk": BuiltinFuncs.walk,
         ]
     }
 

--- a/Sources/Rego/Builtins/Walk.swift
+++ b/Sources/Rego/Builtins/Walk.swift
@@ -1,0 +1,55 @@
+import AST
+import Foundation
+
+extension BuiltinFuncs {
+
+    // Note(philipc): We can't optimize the walk builtin for the
+    // "path not used" cases, like what is done in upstream OPA, because
+    // in the IR we don't get any information at the callsite about
+    // wildcard/"don't care" values in the output array.
+    static func walk(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+
+        guard !args[0].isUndefined else {
+            return .undefined
+        }
+
+        return try .array(walkRegoValueDFS(path: [], source: args[0]))
+    }
+
+    private static func walkRegoValueDFS(path: [RegoValue], source: AST.RegoValue) throws -> (
+        [AST.RegoValue]
+    ) {
+        var result: [AST.RegoValue] = []
+
+        // The * case for aggregate types.
+        if source.isCollection {
+            result.append([.array(path), source])
+        }
+
+        // For both Object and Set types, we have to walk their values in
+        // sorted order to match OPA's behavior.
+        switch source {
+        case .array(let arr):
+            for i in 0..<arr.count {
+                let k: AST.RegoValue = .number(RegoNumber(value: Int64(i)))
+                let v = arr[i] as AST.RegoValue
+                try result.append(contentsOf: walkRegoValueDFS(path: path + [k], source: v))
+            }
+        case .object(let o):
+            for (k, v) in o.sorted(by: { $0.key < $1.key }) {
+                try result.append(contentsOf: walkRegoValueDFS(path: path + [k], source: v))
+            }
+        case .set(let set):
+            for v in set.sorted(by: { $0 < $1 }) {
+                try result.append(contentsOf: walkRegoValueDFS(path: path + [v], source: v))
+            }
+        default:
+            result.append([.array(path), source])
+        }
+
+        return result
+    }
+}

--- a/Tests/RegoTests/BuiltinTests/WalkTests.swift
+++ b/Tests/RegoTests/BuiltinTests/WalkTests.swift
@@ -1,0 +1,119 @@
+import AST
+import Foundation
+import Testing
+
+@testable import Rego
+
+extension BuiltinTests {
+    @Suite("BuiltinTests - Walk", .tags(.builtins))
+    struct WalkTests {}
+}
+
+extension BuiltinTests.WalkTests {
+    static let walkTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "undefined",
+            name: "walk",
+            args: [
+                .undefined
+            ],
+            expected: .success(.undefined)
+        ),
+        BuiltinTests.TestCase(
+            description: "scalar - number",
+            name: "walk",
+            args: [
+                .number(1)
+            ],
+            expected: .success(.array([[[], 1]]))
+        ),
+        BuiltinTests.TestCase(
+            description: "flat array of strings",
+            name: "walk",
+            args: [
+                [
+                    "A",
+                    "B",
+                    "C",
+                ]
+            ],
+            expected: .success(
+                .array([
+                    [[], ["A", "B", "C"]],
+                    [[0], "A"],
+                    [[1], "B"],
+                    [[2], "C"],
+                ])
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "nested object",
+            name: "walk",
+            args: [
+                ["b": ["v1": "hello", "v2": "goodbye"]]
+            ],
+            expected: .success(
+                .array([
+                    [[], ["b": ["v1": "hello", "v2": "goodbye"]]],
+                    [["b"], ["v1": "hello", "v2": "goodbye"]],
+                    [["b", "v1"], "hello"],
+                    [["b", "v2"], "goodbye"],
+                ])
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "nested array",
+            name: "walk",
+            args: [
+                [
+                    ["A", "B", "C"],
+                    ["D", "E", "F"],
+                ]
+            ],
+            expected: .success(
+                .array([
+                    [[], [["A", "B", "C"], ["D", "E", "F"]]],
+                    [[0], ["A", "B", "C"]],
+                    [[0, 0], "A"],
+                    [[0, 1], "B"],
+                    [[0, 2], "C"],
+                    [[1], ["D", "E", "F"]],
+                    [[1, 0], "D"],
+                    [[1, 1], "E"],
+                    [[1, 2], "F"],
+                ])
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "nested sets",
+            name: "walk",
+            args: [
+                .set([1, .set([2, 3])])
+            ],
+            expected: .success(
+                .array([
+                    [[], .set([1, .set([2, 3])])],
+                    [[1], 1],
+                    [[.set([2, 3])], .set([2, 3])],
+                    [[.set([2, 3]), 2], 2],
+                    [[.set([2, 3]), 3], 3],
+                ])
+            )
+        ),
+    ]
+    static var allTests: [BuiltinTests.TestCase] {
+        [
+            BuiltinTests.generateFailureTests(
+                builtinName: "walk", sampleArgs: [[1, 2, 3]],
+                argIndex: 0, argName: "x",
+                allowedArgTypes: ["undefined", "boolean", "null", "number", "string", "array", "object", "set"],
+                generateNumberOfArgsTest: true),
+            walkTests,
+        ].flatMap { $0 }
+    }
+
+    @Test(arguments: allTests)
+    func testBuiltins(tc: BuiltinTests.TestCase) async throws {
+        try await BuiltinTests.testBuiltin(tc: tc)
+    }
+}

--- a/capabilities.json
+++ b/capabilities.json
@@ -1812,6 +1812,32 @@
       },
       "name" : "uuid.rfc4122",
       "nondeterministic" : true
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "static" : [
+            {
+              "dynamic" : {
+                "type" : "any"
+              },
+              "type" : "array"
+            },
+            {
+              "type" : "any"
+            }
+          ],
+          "type" : "array"
+        },
+        "type" : "function"
+      },
+      "name" : "walk",
+      "relation" : true
     }
   ],
   "features" : [


### PR DESCRIPTION
## What changed?

This commit adds the [`walk()` builtin](https://www.openpolicyagent.org/docs/policy-reference/builtins/graph#builtin-graph-walk) from OPA. It recursively enumerates with a DFS traversal all of the path -> value pairs in a Rego collection. 

Because we are working at the IR level, we can't directly translate over some of the optimizations OPA makes around unused path values in the result. This means that these two rules, `x` and `y`, have the same cost to evaluate in Swift OPA:
```rego
x contains [value] if {
	# OPA can introspect on the output variables to detect
	# the wildcard pattern-match here.
	walk([1, 2, 3], [_, value])
}

y contains [path, value] if {
	walk([1, 2, 3], [path, value])
}
```

I have some ideas around how we can mitigate that performance difference in the future, but it's out-of-scope for this PR.

## How to test?

`make test` should pick this new test suite up as part of the overall builtin test suite.

Test cases were ported over after looking for unique examples in the [`v1/test/cases/testdata/v1/walkbuiltin`](https://github.com/open-policy-agent/opa/tree/main/v1/test/cases/testdata/v1/walkbuiltin) folder in OPA.

I also tried each example out in the Rego playground first, to make sure I was encoding the intended behavior into the tests for things like the "nested set" case.

## Other remarks

A pleasant side-effect of porting this builtin over to Swift was that I found I could express the recursive-DFS algorithm in a very straightforward and natural way. 😄 

## Further reading

 - [`v1/topdown/walk.go` in OPA](https://github.com/open-policy-agent/opa/blob/main/v1/topdown/walk.go)
 - [interned `walkBuiltin` implementation in EOPA's VM interpreter](https://github.com/open-policy-agent/eopa/blob/main/pkg/vm/builtins.go#L673C1-L719C2)