### PR TITLE
config: Add initial OPA config structs for `services` top-level key.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
             ]
         ),
+        .target(name: "Config"),
         // Internal module tests
         .testTarget(
             name: "ASTTests",
@@ -59,6 +60,10 @@ let package = Package(
             name: "RegoTests",
             dependencies: ["Rego"],
             resources: [.copy("TestData")]
+        ),
+        .testTarget(
+            name: "ConfigTests",
+            dependencies: ["Config"]
         ),
         // Public API surface tests
         .testTarget(

--- a/Sources/Config/RESTAuthPlugins/AzureManagedIdentities.swift
+++ b/Sources/Config/RESTAuthPlugins/AzureManagedIdentities.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+// MARK: - Azue Managed Identities Authentication Plugin
+// From: v1/plugins/rest/azure.go
+
+private let azureIMDSEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token"
+private let defaultAPIVersion = "2018-02-01"
+private let defaultResource = "https://storage.azure.com/"
+private let defaultAPIVersionForAppServiceMsi = "2019-08-01"
+private let defaultKeyVaultAPIVersion = "7.4"
+
+/// Uses an Azure Managed Identities token's access token for bearer authorization
+public struct AzureManagedIdentitiesAuthPlugin: Codable, Equatable {
+    let endpoint: String
+    let apiVersion: String
+    let resource: String
+    let objectID: String
+    let clientID: String
+    let miResID: String
+    let useAppServiceMsi: Bool?  // Msi -> "Managed Service Identity"
+
+    enum CodingKeys: String, CodingKey {
+        case endpoint
+        case apiVersion = "api_version"
+        case resource
+        case objectID = "object_id"
+        case clientID = "client_id"
+        case miResID = "mi_res_id"
+        case useAppServiceMsi = "use_app_service_msi"
+    }
+
+    /// Note: If endpoint is left blank, the initializer will look up the `IDENTITY_ENDPOINT` environment variable.
+    public init(
+        endpoint: String = "",
+        apiVersion: String = "",
+        resource: String = "",
+        objectID: String,
+        clientID: String,
+        miResID: String
+    ) {
+        (self.endpoint, self.apiVersion, self.resource, self.useAppServiceMsi) =
+            AzureManagedIdentitiesAuthPlugin.getDefaults(
+                endpoint, apiVersion, resource)
+
+        self.objectID = objectID
+        self.clientID = clientID
+        self.miResID = miResID
+    }
+
+    private static func getDefaults(_ endpoint: String, _ apiVersion: String, _ resource: String) -> (
+        String, String, String, Bool
+    ) {
+        var outEndpoint = endpoint
+        var outApiVersion = apiVersion
+        var outResource = resource
+        var useAppServiceMsi = false
+
+        if endpoint.isEmpty {
+            if let identityEndpoint = ProcessInfo.processInfo.environment["IDENTITY_ENDPOINT"] {
+                outEndpoint = identityEndpoint
+                useAppServiceMsi = true
+            } else {
+                outEndpoint = azureIMDSEndpoint
+            }
+        }
+
+        if resource.isEmpty {
+            outResource = defaultResource
+        }
+
+        if apiVersion.isEmpty {
+            if useAppServiceMsi {
+                outApiVersion = defaultAPIVersionForAppServiceMsi
+            } else {
+                outApiVersion = defaultAPIVersion
+            }
+        }
+
+        return (outEndpoint, outApiVersion, outResource, useAppServiceMsi)
+    }
+}

--- a/Sources/Config/RESTAuthPlugins/BearerAuth.swift
+++ b/Sources/Config/RESTAuthPlugins/BearerAuth.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+// MARK: - Bearer Authentication Plugin
+// From: v1/plugins/rest/auth.go
+
+/// Authentication via a bearer token in the HTTP Authorization header
+public struct BearerAuthPlugin: Codable, Equatable {
+    public let token: String?
+    public let tokenPath: String?
+    public let scheme: String?
+
+    public init(
+        token: String? = nil,
+        tokenPath: String? = nil,
+        scheme: String? = nil
+    ) {
+        self.token = token
+        self.tokenPath = tokenPath
+        self.scheme = scheme
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case token
+        case tokenPath = "token_path"
+        case scheme
+    }
+}

--- a/Sources/Config/RESTAuthPlugins/ClientTLS.swift
+++ b/Sources/Config/RESTAuthPlugins/ClientTLS.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+// MARK: - Client TLS Authentication Plugin
+// From: v1/plugins/rest/auth.go
+
+/// Authentication via client certificate on a TLS connection
+public struct ClientTLSAuthPlugin: Codable, Equatable {
+    public let cert: String
+    public let privateKey: String
+    public let privateKeyPassphrase: String?
+    /// Deprecated: Use `services[_].tls.ca_cert` instead
+    public let caCert: String?
+    /// Deprecated: Use `services[_].tls.system_ca_required` instead
+    public let systemCARequired: Bool?
+
+    public init(
+        cert: String,
+        privateKey: String,
+        privateKeyPassphrase: String? = nil,
+        caCert: String? = nil,
+        systemCARequired: Bool? = nil
+    ) {
+        self.cert = cert
+        self.privateKey = privateKey
+        self.privateKeyPassphrase = privateKeyPassphrase
+        self.caCert = caCert
+        self.systemCARequired = systemCARequired
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case cert
+        case privateKey = "private_key"
+        case privateKeyPassphrase = "private_key_passphrase"
+        case caCert = "ca_cert"
+        case systemCARequired = "system_ca_required"
+    }
+}

--- a/Sources/Config/RESTAuthPlugins/GCPMetadata.swift
+++ b/Sources/Config/RESTAuthPlugins/GCPMetadata.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+// MARK: - GCP Metadata Authentication Plugin
+// From: v1/plugins/rest/gcp.go
+
+private let defaultGCPMetadataEndpoint = "http://metadata.google.internal"
+private let defaultAccessTokenPath = "/computeMetadata/v1/instance/service-accounts/default/token"
+private let defaultIdentityTokenPath = "/computeMetadata/v1/instance/service-accounts/default/identity"
+
+/// Represents authentication via GCP metadata service
+public struct GCPMetadataAuthPlugin: Codable, Equatable {
+    let accessTokenPath: String
+    let audience: String?
+    let endpoint: String
+    let identityTokenPath: String
+    let scopes: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case accessTokenPath = "access_token_path"
+        case audience
+        case endpoint
+        case identityTokenPath = "identity_token_path"
+        case scopes
+    }
+
+    // Note: The default values set here are derived from the `NewClient()`
+    // method for this type over in OPA. This behavior may be refactored in
+    // in the future when we decide where config validation should be happening.
+    public init(
+        accessTokenPath: String? = nil,
+        audience: String? = nil,
+        endpoint: String?,
+        identityTokenPath: String? = nil,
+        scopes: [String] = []
+    ) {
+        self.accessTokenPath = accessTokenPath ?? defaultAccessTokenPath
+        self.audience = audience ?? ""
+        self.endpoint = endpoint ?? defaultGCPMetadataEndpoint
+        self.identityTokenPath = identityTokenPath ?? defaultIdentityTokenPath
+        self.scopes = scopes
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let accessTokenPath =
+            try container.decodeIfPresent(String.self, forKey: .accessTokenPath)
+        self.accessTokenPath = accessTokenPath ?? defaultAccessTokenPath
+
+        self.audience = try container.decodeIfPresent(String.self, forKey: .audience)
+
+        let endpoint = try container.decodeIfPresent(String.self, forKey: .endpoint)
+        self.endpoint = endpoint ?? defaultGCPMetadataEndpoint
+
+        let identityTokenPath =
+            try container.decodeIfPresent(String.self, forKey: .identityTokenPath)
+
+        self.identityTokenPath = identityTokenPath ?? defaultIdentityTokenPath
+        self.scopes = try container.decodeIfPresent([String].self, forKey: .scopes) ?? []
+
+        guard !(self.audience == nil && self.scopes.count == 0) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .audience,
+                in: container,
+                debugDescription: "audience or scopes is required when gcp metadata is enabled"
+            )
+        }
+
+        guard !(self.audience != nil && self.scopes.count > 0) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .audience,
+                in: container,
+                debugDescription: "either audience or scopes can be set, not both, when gcp metadata is enabled"
+            )
+        }
+    }
+}

--- a/Sources/Config/RestClientServiceConfig.swift
+++ b/Sources/Config/RestClientServiceConfig.swift
@@ -1,0 +1,255 @@
+// This file contains struct definitions for parsing the
+// `services` section of an OPA configuration file.
+// See: https://www.openpolicyagent.org/docs/configuration#services
+import Foundation
+
+// MARK: - REST Client Configuration
+// From: v1/plugins/rest/rest.go
+
+/// Configuration for a REST client service
+public struct RestClientServiceConfig: Codable, Equatable {
+    public let name: String
+    public let url: URL
+    public let headers: [String: String]?
+    public let allowInsecureTLS: Bool?
+    public let responseHeaderTimeoutSeconds: Int64?
+    public let tls: ServerTLSConfig?
+    public let credentials: Credentials?
+    public let type: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case url
+        case headers
+        case allowInsecureTLS = "allow_insecure_tls"
+        case responseHeaderTimeoutSeconds = "response_header_timeout_seconds"
+        case tls
+        case credentials
+        case type
+    }
+
+    public init(
+        name: String,
+        url: URL,
+        headers: [String: String]? = nil,
+        allowInsecureTLS: Bool? = nil,
+        responseHeaderTimeoutSeconds: Int64? = nil,
+        tls: ServerTLSConfig? = nil,
+        credentials: Credentials? = nil,
+        type: String? = nil
+    ) {
+        self.name = name
+        self.url = url
+        self.headers = headers
+        self.allowInsecureTLS = allowInsecureTLS
+        self.responseHeaderTimeoutSeconds = responseHeaderTimeoutSeconds
+        self.tls = tls
+        self.credentials = credentials
+        self.type = type
+    }
+
+    // MARK: - Credentials (tagged union)
+
+    /// Credentials represents the default set of REST client credential
+    /// options supported by OPA for fetching bundles from remote sources.
+    ///
+    /// If a custom plugin name is provided, there won't be any associated
+    /// config keys in this section-- any configuration will appear under the
+    /// `plugins` section.
+    public enum Credentials: Codable, Equatable {
+        case bearer(BearerAuthPlugin)
+        case oauth2([String: AnyCodable])
+        case clientTLS(ClientTLSAuthPlugin)
+        case s3Signing([String: AnyCodable])
+        case gcpMetadata(GCPMetadataAuthPlugin)
+        case azureManagedIdentity(AzureManagedIdentitiesAuthPlugin)
+        case custom(String)
+
+        private enum CodingKeys: String, CodingKey {
+            case bearer
+            case oauth2
+            case clientTLS = "client_tls"
+            case s3Signing = "s3_signing"
+            case gcpMetadata = "gcp_metadata"
+            case azureManagedIdentity = "azure_managed_identity"
+            case custom = "plugin"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            // Check if plugin field is present.
+            if let pluginName = try container.decodeIfPresent(String.self, forKey: .custom) {
+                self = .custom(pluginName)
+            } else {
+                // Fall back to trying each credential type.
+                let attemptedCredentialTypes: [Credentials?] = [
+                    try? container.decodeIfPresent(BearerAuthPlugin.self, forKey: .bearer).map { .bearer($0) },
+                    try? container.decodeIfPresent([String: AnyCodable].self, forKey: .oauth2).map { .oauth2($0) },
+                    try? container.decodeIfPresent(ClientTLSAuthPlugin.self, forKey: .clientTLS).map { .clientTLS($0) },
+                    try? container.decodeIfPresent([String: AnyCodable].self, forKey: .s3Signing).map {
+                        .s3Signing($0)
+                    },
+                    try? container.decodeIfPresent(GCPMetadataAuthPlugin.self, forKey: .gcpMetadata).map {
+                        .gcpMetadata($0)
+                    },
+                    try? container.decodeIfPresent(AzureManagedIdentitiesAuthPlugin.self, forKey: .azureManagedIdentity)
+                        .map {
+                            .azureManagedIdentity($0)
+                        },
+                ]
+
+                let foundCredentials = attemptedCredentialTypes.compactMap { $0 }
+
+                guard foundCredentials.count == 1 else {
+                    throw DecodingError.dataCorrupted(
+                        DecodingError.Context(
+                            codingPath: container.codingPath,
+                            debugDescription: foundCredentials.isEmpty
+                                ? "No valid credential type found"
+                                : "Expected exactly one credential type, but found \(foundCredentials.count)"
+                        )
+                    )
+                }
+
+                self = foundCredentials[0]
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            switch self {
+            case .bearer(let plugin):
+                try container.encode(plugin, forKey: .bearer)
+            case .oauth2(let config):
+                try container.encode(config, forKey: .oauth2)
+            case .clientTLS(let plugin):
+                try container.encode(plugin, forKey: .clientTLS)
+            case .s3Signing(let config):
+                try container.encode(config, forKey: .s3Signing)
+            case .gcpMetadata(let config):
+                try container.encode(config, forKey: .gcpMetadata)
+            case .azureManagedIdentity(let config):
+                try container.encode(config, forKey: .azureManagedIdentity)
+            case .custom(let plugin):
+                try container.encode(plugin, forKey: .custom)
+            }
+        }
+    }
+}
+
+// MARK: - Server TLS Configuration
+// From: v1/plugins/rest/auth.go
+
+public struct ServerTLSConfig: Codable, Equatable {
+    public let caCert: String?
+    public let systemCARequired: Bool?
+
+    public init(
+        caCert: String? = nil,
+        systemCARequired: Bool? = nil
+    ) {
+        self.caCert = caCert
+        self.systemCARequired = systemCARequired
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case caCert = "ca_cert"
+        case systemCARequired = "system_ca_required"
+    }
+}
+
+// MARK: - AnyCodable Helper
+
+/// A type-erased Codable value.
+/// We should be able to remove this once we finish plumbing in Config types.
+public struct AnyCodable: Codable, Equatable {
+    public let value: Any
+
+    public init(_ value: Any) {
+        self.value = value
+    }
+
+    public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+        switch lhs.value {
+        case let bool as Bool:
+            return bool == (rhs.value as? Bool)
+        case let int as Int:
+            return int == (rhs.value as? Int)
+        case let double as Double:
+            return double == (rhs.value as? Double)
+        case let string as String:
+            return string == (rhs.value as? String)
+        case let array as [Any]:
+            guard let rhsArray = rhs.value as? [Any] else { return false }
+            return array.count == rhsArray.count
+                && zip(array, rhsArray).allSatisfy {
+                    AnyCodable($0) == AnyCodable($1)
+                }
+        case let dict as [String: Any]:
+            guard let rhsDict = rhs.value as? [String: Any] else { return false }
+            guard dict.keys.count == rhsDict.keys.count else { return false }
+            return dict.keys.allSatisfy { key in
+                guard let lhsValue = dict[key], let rhsValue = rhsDict[key] else { return false }
+                return AnyCodable(lhsValue) == AnyCodable(rhsValue)
+            }
+        case is NSNull:
+            return rhs.value is NSNull
+        default:
+            return false
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let bool = try? container.decode(Bool.self) {
+            value = bool
+        } else if let int = try? container.decode(Int.self) {
+            value = int
+        } else if let double = try? container.decode(Double.self) {
+            value = double
+        } else if let string = try? container.decode(String.self) {
+            value = string
+        } else if let array = try? container.decode([AnyCodable].self) {
+            value = array.map(\.value)
+        } else if let dictionary = try? container.decode([String: AnyCodable].self) {
+            value = dictionary.mapValues(\.value)
+        } else if container.decodeNil() {
+            value = NSNull()
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "AnyCodable cannot decode value"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any]:
+            try container.encode(array.map { AnyCodable($0) })
+        case let dict as [String: Any]:
+            try container.encode(dict.mapValues { AnyCodable($0) })
+        case is NSNull:
+            try container.encodeNil()
+        default:
+            let context = EncodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "AnyCodable cannot encode value of type \(type(of: value))"
+            )
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
+}

--- a/Tests/ConfigTests/RestClientConfigTests.swift
+++ b/Tests/ConfigTests/RestClientConfigTests.swift
@@ -1,0 +1,363 @@
+import Foundation
+import Testing
+
+@testable import Config
+
+@Suite
+struct RestClientServiceConfigTests {
+    struct TestCase {
+        var description: String
+        var input: String
+        var wantErr: Bool = false
+        var env: [String: String] = [:]
+    }
+
+    static var allTests: [TestCase] {
+        return [
+            TestCase(
+                description: "BadScheme",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "bad scheme://authority"
+                    }
+                    """,
+                wantErr: true
+            ),
+            TestCase(
+                description: "ValidUrl",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost/some/path"
+                    }
+                    """
+            ),
+            TestCase(
+                description: "Token",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "bearer": {
+                                "token": "secret"
+                            }
+                        }
+                    }
+                    """
+            ),
+            TestCase(
+                description: "TokenWithScheme",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "bearer": {
+                                "scheme": "Acmecorp-Token",
+                                "token": "secret"
+                            }
+                        }
+                    }
+                    """
+            ),
+            TestCase(
+                description: "MissingTlsOptions",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "client_tls": {}
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+            TestCase(
+                description: "IncompleteTlsOptions",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "client_tls": {
+                                "cert": "cert.pem"
+                            }
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+            TestCase(
+                description: "MultipleCredentialsOptions",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "s3_signing": {
+                                "environment_credentials": {}
+                            },
+                            "bearer": {
+                                "scheme": "Acmecorp-Token",
+                                "token": "secret"
+                            }
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+            // Tests that were not ported over:
+
+            // TestCase(
+            // 	description: "EmptyS3Options",
+            // ),
+            // TestCase(
+            // 	description: "ValidS3EnvCreds",
+            // ),
+            // TestCase(
+            // 	description: "ValidApiGatewayEnvCreds",
+            // ),
+            // TestCase(
+            // 	description: "ValidS3MetadataCredsWithRole",
+            // ),
+            // TestCase(
+            // 	description: "ValidS3MetadataCreds",
+            // ),
+            // TestCase(
+            // 	description: "MissingS3MetadataCredOptions",
+            // ),
+            // TestCase(
+            // 	description: "MultipleS3CredOptions/metadata+environment",
+            // ),
+            // TestCase(
+            // 	description: "MultipleS3CredOptions/metadata+profile+environment+webidentity",
+            // ),
+            // TestCase(
+            // 	description: "MultipleCredentialsOptions",
+            // ),
+            // TestCase(
+            // 	description: "S3WebIdentityMissingEnvVars",
+            // ),
+            // TestCase(
+            // 	description: "S3WebIdentityCreds",
+            // ),
+            // TestCase(
+            // 	description: "S3AssumeRoleMissingEnvVars",
+            // ),
+            // TestCase(
+            // 	description: "S3AssumeRoleCredsMissingSigningPlugin",
+            // ),
+            // TestCase(
+            // 	description: "S3AssumeRoleCreds",
+            // ),
+
+            // TestCase(
+            // 	description: "Oauth2NoTokenUrl",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2MissingScopes",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2MissingClientId",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2MissingSecret",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2Creds",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2GetCredScopes",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2JwtBearerMissingSigningKey",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2JwtBearerSigningKeyWithoutCorrespondingKey",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2JwtBearerSigningKeyWithCorrespondingKey",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2JwtBearerSigningKeyPublicKeyReference",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2WrongGrantType",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsMissingCredentials",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsJwtNoAdditionalClaims",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsJwtThumbprint",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsTooManyCredentials",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsJWTAuthentication",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsJWTAuthentication_with_AWS_KMS",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsJWTAuthentication_with_AWS_KMS_missing_credentials",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsJWTAuthentication with Azure KeyVault",
+            // ),
+            // TestCase(
+            // 	description: "Oauth2ClientCredentialsJWTAuthentication with Azure KeyVault and missing managed identity",
+            // ),
+            // TestCase(
+            //  description: "Oauth2CredsClientAssertionPath",
+            // ),
+            // TestCase(
+            //  description: "Oauth2CredsClientAssertion",
+            // ),
+            TestCase(
+                description: "ValidGCPMetadataIDTokenOptions",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "https://localhost",
+                        "credentials": {
+                            "gcp_metadata": {
+                                "audience": "https://localhost"
+                            }
+                        }
+                    }
+                    """
+            ),
+            TestCase(
+                description: "ValidGCPMetadataAccessTokenOptions",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "https://localhost",
+                        "credentials": {
+                            "gcp_metadata": {
+                                "scopes": ["storage.read_only"]
+                            }
+                        }
+                    }
+                    """
+            ),
+            TestCase(
+                description: "EmptyGCPMetadataOptions",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "gcp_metadata": {
+                            }
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+            TestCase(
+                description: "EmptyGCPMetadataIDTokenAudienceOption",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "https://localhost",
+                        "credentials": {
+                            "gcp_metadata": {
+                                "audience": ""
+                            }
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+            TestCase(
+                description: "EmptyGCPMetadataAccessTokenScopesOption",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "https://localhost",
+                        "credentials": {
+                            "gcp_metadata": {
+                                "scopes": []
+                            }
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+            TestCase(
+                description: "InvalidGCPMetadataOptions",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "https://localhost",
+                        "credentials": {
+                            "gcp_metadata": {
+                                "audience": "https://localhost",
+                                "scopes": ["storage.read_only"]
+                            }
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+            TestCase(
+                description: "Plugin",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "plugin": "my_plugin"
+                        }
+                    }
+                    """
+            ),
+            TestCase(
+                description: "Unknown plugin",
+                input: """
+                    {
+                        "name": "foo",
+                        "url": "http://localhost",
+                        "credentials": {
+                            "plugin": "unknown_plugin"
+                        }
+                    }
+                    """,
+                wantErr: true
+            ),
+        ]
+    }
+
+    @Test(arguments: allTests)
+    func testRoundtripSerdes(tc: TestCase) throws {
+        let rawConfig = tc.input
+        do {
+            let parsedConfig = try JSONDecoder().decode(
+                RestClientServiceConfig.self, from: rawConfig.data(using: .utf8)!)
+            let encodedConfig = try JSONEncoder().encode(parsedConfig)
+
+            let roundTrippedConfig = try JSONDecoder().decode(
+                RestClientServiceConfig.self, from: encodedConfig)
+
+            // Comapre the first config we parsed against the round-tripped one.
+            #expect(parsedConfig == roundTrippedConfig)
+        } catch {
+            guard tc.wantErr else {
+                throw error
+            }
+            return  // Error was expected. Continue.
+        }
+    }
+}
+
+extension RestClientServiceConfigTests.TestCase: CustomTestStringConvertible {
+    var testDescription: String { description }
+}


### PR DESCRIPTION
## What changed?

This commit contains basic struct definitions in Swift for supporting the `services` key in OPA configuration files.

We currently support parsing:
 - Custom plugins
 - Bearer auth
 - Client TLS auth (mTLS)
 - Azure managed identities auth
 - GCP metadata auth

Not supported yet:
 - S3 signing (AWS)
 - OAuth2

The AWS and OAuth2 definitions were left out of this initial implementation, because of how tangled and messy those configs are in the Golang codebase.

## How to test?

 - `make test` picks up the new `Config` module tests automatically.
   - These currently only test that round-tripping serdes works as expected. The test cases were ported over from: [`github.com/open-policy-agent/opa/tree/main/v1/plugins/rest/rest_test.go`](github.com/open-policy-agent/opa/tree/main/v1/plugins/rest/rest_test.go)

## Further reading

 - Partially implements: #89 