### PR TITLE
builtins: Add `json` encoding builtins.

### DIFF
--- a/Sources/Rego/Builtins/Encoding.swift
+++ b/Sources/Rego/Builtins/Encoding.swift
@@ -2,6 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
+    // MARK: - base64.encode
     static func base64Encode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -14,6 +15,7 @@ extension BuiltinFuncs {
         return .string(Data(x.utf8).base64EncodedString())
     }
 
+    // MARK: - base64.decode
     static func base64Decode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -30,6 +32,7 @@ extension BuiltinFuncs {
         return .string(String(decoding: data, as: UTF8.self))
     }
 
+    // MARK: - base64.is_valid
     static func base64IsValid(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -42,6 +45,7 @@ extension BuiltinFuncs {
         return .boolean(Data(base64Encoded: x, options: Data.Base64DecodingOptions(rawValue: 0)) != nil)
     }
 
+    // MARK: - base64url.encode
     static func base64UrlEncode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -58,6 +62,7 @@ extension BuiltinFuncs {
         return .string(encoded)
     }
 
+    // MARK: - base64url.encode_no_pad
     static func base64UrlEncodeNoPad(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -75,6 +80,7 @@ extension BuiltinFuncs {
         return .string(encoded)
     }
 
+    // MARK: - base64url.decode
     static func base64UrlDecode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -98,6 +104,7 @@ extension BuiltinFuncs {
         return .string(String(decoding: data, as: UTF8.self))
     }
 
+    // MARK: - hex.encode
     static func hexEncode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -110,6 +117,7 @@ extension BuiltinFuncs {
         return .string(Data(x.utf8).hexEncoded)
     }
 
+    // MARK: - hex.decode
     static func hexDecode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -127,6 +135,59 @@ extension BuiltinFuncs {
         }
 
         return .string(hexDecoded)
+    }
+
+    // MARK: - json.is_valid
+    /// Verifies the input string is a valid JSON document.
+    public static func jsonIsValid(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+
+        guard case .string(let rawJSON) = args[0] else {
+            return AST.RegoValue(booleanLiteral: false)
+        }
+
+        let parsedOK = (try? JSONDecoder().decode(RegoValue.self, from: rawJSON.data(using: .utf8)!)) != nil
+
+        // The result of the JSON parsing should be nil if parsing fails, or we got an empty input.
+        return AST.RegoValue(booleanLiteral: parsedOK)
+    }
+
+    // MARK: - json.marshal
+    /// Serializes the input term to JSON.
+    public static func jsonMarshal(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        let data = try encoder.encode(args[0])
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw Rego.RegoError(code: .internalError, message: "json.marshal: failed to encode JSON as utf-8")
+        }
+
+        return AST.RegoValue(stringLiteral: json)
+    }
+
+    // MARK: - json.marshal_with_options
+    // TODO: Implement this JSON encoding builtin.
+
+    // MARK: - json.unmarshal
+    /// Deserializes the input JSON string to a term.
+    public static func jsonUnmarshal(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+
+        guard case .string(let rawJSON) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "x", got: args[0].typeName, want: "string")
+        }
+
+        // Returns the parsed RegoValue, or throws an error.
+        return try JSONDecoder().decode(RegoValue.self, from: rawJSON.data(using: .utf8)!)
     }
 }
 

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -113,6 +113,9 @@ public struct BuiltinRegistry: Sendable {
             "base64url.decode": BuiltinFuncs.base64UrlDecode,
             "hex.encode": BuiltinFuncs.hexEncode,
             "hex.decode": BuiltinFuncs.hexDecode,
+            "json.is_valid": BuiltinFuncs.jsonIsValid,
+            "json.marshal": BuiltinFuncs.jsonMarshal,
+            "json.unmarshal": BuiltinFuncs.jsonUnmarshal,
 
             // Numbers
             "numbers.range": BuiltinFuncs.numbersRange,

--- a/Tests/RegoTests/BuiltinTests/EncodingTests.swift
+++ b/Tests/RegoTests/BuiltinTests/EncodingTests.swift
@@ -10,6 +10,8 @@ extension BuiltinTests {
 }
 
 extension BuiltinTests.EncodingTests {
+
+    // MARK: - base64.encode Tests
     static let base64EncodeTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "encodes empty string",
@@ -25,6 +27,7 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - base64.decode Tests
     static let base64DecodeTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "decodes empty string",
@@ -46,6 +49,7 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - base64.is_valid Tests
     static let base64IsValidTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "returns true for empty string",
@@ -67,6 +71,7 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - hex.encode Tests
     static let hexEncodeTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "encodes empty string",
@@ -82,6 +87,7 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - hex.decode Tests
     static let hexDecodeTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "decodes empty string",
@@ -115,6 +121,7 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - base64url.encode Tests
     static let base64UrlEncodeTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "encodes empty string",
@@ -137,6 +144,7 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - base64url.encode_no_pad Tests
     static let base64UrlEncodeNoPadTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "encodes empty string",
@@ -159,6 +167,7 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - base64url.decode Tests
     static let base64UrlDecodeTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "decodes empty string",
@@ -195,6 +204,94 @@ extension BuiltinTests.EncodingTests {
             name: "base64url.decode",
             args: ["this is not a valid base64 input"],
             expected: .failure(BuiltinError.evalError(msg: "invalid base64 string"))
+        ),
+    ]
+
+    // MARK: - json.is_valid Tests
+    static let jsonIsValidTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "invalid - empty string",
+            name: "json.is_valid",
+            args: ["plainstring"],
+            expected: .success(.boolean(false))
+        ),
+        BuiltinTests.TestCase(
+            description: "invalid - unquoted string",
+            name: "json.is_valid",
+            args: ["plainstring"],
+            expected: .success(.boolean(false))
+        ),
+        BuiltinTests.TestCase(
+            description: "invalid - unclosed brace",
+            name: "json.is_valid",
+            args: ["{"],
+            expected: .success(.boolean(false))
+        ),
+        BuiltinTests.TestCase(
+            description: "valid - simple object",
+            name: "json.is_valid",
+            args: ["{\"json\": \"ok\"}"],
+            expected: .success(.boolean(true))
+        ),
+        // Note: Surprisingly, Swift's JSONDecoder allows trailing commas!
+        // BuiltinTests.TestCase(
+        //     description: "invalid - trailing comma",
+        //     name: "json.is_valid",
+        //     args: ["{\"foo\": 1,}"],
+        //     expected: .success(.boolean(false))
+        // ),
+        BuiltinTests.TestCase(
+            description: "invalid - non string",
+            name: "json.is_valid",
+            args: [["foo": 1]],
+            expected: .success(.boolean(false))  // Does not throw a builtin error in OPA, surprisingly.
+        ),
+    ]
+
+    // MARK: - json.marshal Tests
+    static let jsonMarshalTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "marshal aggregate rego types",
+            name: "json.marshal",
+            args: [
+                [["foo": .set([1, 2, 3, true, nil])]]
+            ],
+            expected: .success(.string("[{\"foo\":[null,true,1,2,3]}]"))
+        ),
+        BuiltinTests.TestCase(
+            description: "marshal large integers",
+            name: "json.marshal",
+            args: [
+                .array([.number(1_234_500_000 + 67890), .number(1e6 * 2), .number(1e109 / 1e100)])
+            ],
+            expected: .success(.string("[1234567890,2000000,1000000000]"))
+        ),
+    ]
+
+    // MARK: - json.marshal_with_options Tests
+    static let jsonMarshalWithOptionsTests: [BuiltinTests.TestCase] = [
+        // TODO: Add test cases from: v1/test/cases/testdata/v0/jsonbuiltins/test-json-marshal-with-options.yaml
+    ]
+
+    // MARK: - json.unmarshal Tests
+    static let jsonUnmarshalTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "nested object",
+            name: "json.unmarshal",
+            args: ["[{\"foo\":[1,2,3]}]"],
+            expected: .success([["foo": [1, 2, 3]]])
+        ),
+        BuiltinTests.TestCase(
+            description: "escaped quoted string",
+            name: "json.unmarshal",
+            args: ["\"string\""],
+            expected: .success(.string("string"))
+        ),
+        BuiltinTests.TestCase(
+            description: "boolean",
+            name: "json.unmarshal",
+            args: ["true"],
+            expected: .success(.boolean(true))
         ),
     ]
 
@@ -247,6 +344,30 @@ extension BuiltinTests.EncodingTests {
                 argIndex: 0, argName: "x", allowedArgTypes: ["string"],
                 generateNumberOfArgsTest: true),
             hexDecodeTests,
+
+            // json.is_valid's documentation states it requires a string,
+            // but in the OPA implementation, it does not throw a builtin
+            // error on a wrong-typed argument. Instead it returns false.
+            BuiltinTests.generateFailureTests(
+                builtinName: "json.is_valid", sampleArgs: [""],
+                argIndex: 0, argName: "x",
+                allowedArgTypes: ["undefined", "null", "boolean", "number", "string", "object", "array", "set"],
+                generateNumberOfArgsTest: true),
+            jsonIsValidTests,
+
+            BuiltinTests.generateFailureTests(
+                builtinName: "json.marshal", sampleArgs: [""],
+                argIndex: 0, argName: "x",
+                allowedArgTypes: ["undefined", "null", "boolean", "number", "string", "object", "array", "set"],
+                generateNumberOfArgsTest: true),
+            jsonMarshalTests,
+
+            BuiltinTests.generateFailureTests(
+                builtinName: "json.unmarshal", sampleArgs: [""],
+                argIndex: 0, argName: "x",
+                allowedArgTypes: ["string"],
+                generateNumberOfArgsTest: true),
+            jsonUnmarshalTests,
         ].flatMap { $0 }
     }
 

--- a/capabilities.json
+++ b/capabilities.json
@@ -897,6 +897,48 @@
           }
         ],
         "result" : {
+          "type" : "boolean"
+        },
+        "type" : "function"
+      },
+      "name" : "json.is_valid"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "type" : "string"
+        },
+        "type" : "function"
+      },
+      "name" : "json.marshal"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
+          "type" : "any"
+        },
+        "type" : "function"
+      },
+      "name" : "json.unmarshal"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
           "type" : "string"
         },
         "type" : "function"


### PR DESCRIPTION
### What code changed, and why?

This commit adds the `json` family of encoding builtins. This list includes:

 - [x] `json.is_valid`
 - [x] `json.marshal`
 - ~~`json.marshal_with_options`~~ (We'll tackle this one in a future PR)
 - [x] `json.unmarshal`

For each builtin, test cases were ported over from OPA's test case suite.

### Definition of done

 - ~~Finish `json.marshal_with_options` implementation.~~ (Will be picked up later in issue #118)

### How to test

`make test` picks up the new tests as part of the `BuiltinTests.EncodingTests` test suite.

### Related Resources

