### PR TITLE
ci: Harden CI + Add zizmor static analysis for GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
   # Only updates the go.mod when OPA has a version bump.
   - package-ecosystem: "gomod"
     directory: "/tools/generate-compliance-tests"
@@ -16,3 +18,5 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "github.com/open-policy-agent/opa"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/post-tag.yaml
+++ b/.github/workflows/post-tag.yaml
@@ -24,10 +24,11 @@ jobs:
       - name: Show Swift version
         run: swift --version
       - name: Check out code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: Install jemalloc
         run: brew install jemalloc
       - name: Lint
@@ -47,10 +48,11 @@ jobs:
         # Subsequent jobs will be have the computed tag name
         run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Check out code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - name: Create or Update Release
         env:
           # Required for the GitHub CLI

--- a/.github/workflows/pr-release-check.yaml
+++ b/.github/workflows/pr-release-check.yaml
@@ -5,8 +5,13 @@ name: Release Check
 # or scripts here should depend only on trusted code in main, and
 # not on anything from the PR.
 on:
-  workflow_dispatch: {}
-  pull_request_target: {}
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base branch to compare against (e.g. main)'
+        required: true
+        default: 'main'
+  pull_request: {}
 
 # When a new revision is pushed to a PR, cancel all in-progress CI runs for that
 # PR. See https://docs.github.com/en/actions/using-jobs/using-concurrency
@@ -14,91 +19,61 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   release-check:
     name: Release version check
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      contents: read
     steps:
-      - uses: actions/checkout@v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.base_ref }}  # Use scripts only from trusted base branch
           fetch-depth: 0  # Fetch full history to access all commits
-
-      - name: Fetch PR from fork
-        run: |
-          # Don't allow user to provide branch name. Bind to PR number ref explicitly.
-          git fetch origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
+          persist-credentials: false
 
       - name: Check for release commits
         id: check-release
         run: |
-          RESULT=$(./tools/build/get-release-from-commits.sh "origin/${{ github.base_ref }}" "pr-head")
+          RESULT=$(./tools/build/get-release-from-commits.sh "origin/${GITHUB_BASE_REF}" "HEAD")
           echo "Release commits detected: $RESULT"
           if [ -n "$RESULT" ]; then
             echo "result=true" >> $GITHUB_OUTPUT
+            echo "commit_version=$RESULT" >> $GITHUB_OUTPUT
           else
             echo "result=false" >> $GITHUB_OUTPUT
           fi
-  
+
       - name: Get CHANGELOG version from PR
         if: steps.check-release.outputs.result == 'true'
         id: changelog
         run: |
-          # Checkout just the CHANGELOG from PR
-          git show "pr-head:CHANGELOG.md" > /tmp/changelog-pr.md
-          CHANGELOG_VERSION=$(grep -o -E '## [0-9.]+' /tmp/changelog-pr.md | head -n 1 | sed 's/## //' | grep -E '^[0-9.]+$' || echo "invalid")
+          CHANGELOG_VERSION=$(grep -o -E '## [0-9.]+' CHANGELOG.md | head -n 1 | sed 's/## //' | grep -E '^[0-9.]+$' || echo "invalid")
           echo "version=$CHANGELOG_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Post or update warning comment (release commit detected)
+      - name: Verify release versions match
         if: steps.check-release.outputs.result == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MARKER: "<!-- release-commit-warning -->"
+          COMMIT_VERSION: ${{ steps.check-release.outputs.commit_version }}
+          CHANGELOG_VERSION: ${{ steps.changelog.outputs.version }}
         run: |
-          COMMIT_VERSION=$(./tools/build/get-release-from-commits.sh "origin/${{ github.base_ref }}" "pr-head")
-          CHANGELOG_VERSION="${{ steps.changelog.outputs.version }}"
+          echo "ℹ️ Release Commit Detected"
+          echo ""
+          echo "This PR contains commit(s) that match the case-insensitive regex \`^Release .*\`"
+          echo ""
+          echo "Here are the latest versions reported from the places the release workflows will use:"
+          echo ""
+          echo "| Source | Version |"
+          echo "| --- | --- |"
+          echo "| Commit matching \`^Release .*\` | $COMMIT_VERSION |"
+          echo "| \`CHANGELOG.md\` | $CHANGELOG_VERSION |"
+          echo ""
 
-          COMMENT=$(mktemp)
-          echo "ℹ️ **Release Commit Detected**"                                                        >> "$COMMENT"
-          echo ""                                                                                      >> "$COMMENT"
-          echo "This PR contains commit(s) that match the case-insensitive regex \`^Release .*\`"      >> "$COMMENT"
-          echo ""                                                                                      >> "$COMMENT"
-          echo "Here are the latest versions reported from the places the release workflows will use:" >> "$COMMENT"
-          echo ""                                                                                      >> "$COMMENT"
-          echo "| Source | Version |"                                                                  >> "$COMMENT"
-          echo "| --- | --- |"                                                                         >> "$COMMENT"
-          echo "| Commit matching \`^Release .*\` | $COMMIT_VERSION |"                                 >> "$COMMENT"
-          echo "| \`CHANGELOG.md\` | $CHANGELOG_VERSION |"                                             >> "$COMMENT"
-
-          echo "Posting or updating release warning comment."
-          export COMMENT_BODY="$(cat "$COMMENT")"
-          ./tools/build/release-pr-comment.sh "$REPO" "$PR_NUMBER" "$MARKER"
-
-      - name: Update warning comment if present (no release commit)
-        if: steps.check-release.outputs.result != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          MARKER: "<!-- release-commit-warning -->"
-          COMMENT_BODY: |
-            ℹ️ A release commit was detected in earlier versions of this PR.
-
-            The current PR commits do not appear to be a release.
-        run: |
-          EXISTING_COMMENT=$(gh api repos/$REPO/issues/$PR_NUMBER/comments \
-              --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1) || {
-              echo "Error: Failed to fetch existing comments" >&2
-              exit 2
-          }
-
-          if [ -n "$EXISTING_COMMENT" ]; then
-            echo "Updating release warning comment."
-            ./tools/build/release-pr-comment.sh "$REPO" "$PR_NUMBER" "$MARKER"
-          else
-            echo "No release warning comment found."
+          if [ "$COMMIT_VERSION" != "$CHANGELOG_VERSION" ]; then
+            echo "❌ Version mismatch detected! All sources must agree before creating a release." >&2
+            exit 1
           fi
+
+          echo "✅ All version sources agree: $COMMIT_VERSION"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Build Swift ${{ matrix.swift }}${{ matrix.xcode && format(', Xcode {0}', matrix.xcode) || '' }} (${{ matrix.os }})
@@ -43,7 +46,7 @@ jobs:
         run: |
           sudo xcode-select --switch "${DEVELOPER_DIR}/Contents/Developer"
           xcodebuild -version
-      - uses: swift-actions/setup-swift@v2
+      - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a #v2.4.0
         if: runner.os == 'Linux'
         with:
           swift-version: ${{ matrix.swift }}
@@ -60,7 +63,9 @@ jobs:
             echo "**Version Mismatch**: Expected \`${SWIFT_VERSION}\`, got \`${ACTUAL}\`" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install jemalloc
         if: runner.os == 'macOS'
         run: brew install jemalloc
@@ -84,16 +89,18 @@ jobs:
       - run: sudo xcode-select -s /Applications/Xcode_26.0.app
       - run: swift --version
       - name: checkout PR
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: pr/swift-opa
           fetch-depth: 0 # fetch all history for all branches and tags
+          persist-credentials: false
       - name: checkout main
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: open-policy-agent/swift-opa
           ref: main
           path: main/swift-opa
+          persist-credentials: false
       - name: compliance tests (main)
         run: |
           (make test-compliance || true) > results
@@ -130,7 +137,9 @@ jobs:
       contents: read
     steps:
       - run: sudo xcode-select -s /Applications/Xcode_26.0.app
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: generate capabilities
         run: make generate
       - name: check for changes
@@ -144,3 +153,14 @@ jobs:
             git diff capabilities.json
             exit 1
           fi
+
+  gh-actions-lint:
+    name: Github Actions Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0


### PR DESCRIPTION
### What changed, and why?

This commit fixes all findings from the Github Actions static analysis tool [`zizmor`](https://docs.zizmor.sh/), and adds it to our pull request checks.

It also changes the release commit detection workflow to use the reduced-permissions `pull_request` workflow trigger, and now skips on non-releases. It succeeds/fails only when a release commit is detected.

Unfortunately, due to the `pull_request_target` already being set up on `main`, *that version* of the workflow is what will run on this PR, so we can't test the new reduced-permissions version until it's merged (breaking the "upstream only" behavior). 🙁 

### Definition of done

 - Do the existing workflows still pass?
 - ~~Do release commits get detected / handled correctly in the detection workflow?~~
   - ~~Skip: Normal PR, no release commit.~~
   - ~~Fail: Release commit, version mismatches.~~
   - ~~Pass: Release commit, versions all match.~~
 - We'll test the release commit detection in a follow-up PR (with the above strategy)

### How to test

 - Allow normal CI to run for this PR.
 - ~~For testing release workflow:~~
   - ~~Skip: tested by the base state of this PR.~~
   - ~~Fail: Push release commit to the PR branch with version mismatch.~~
   - ~~Pass: Push release commit to the PR branch with all versions matched.~~

### Related Resources

 - Prior art: https://github.com/open-policy-agent/opa/pull/8356