### PR TITLE
Rego/Store: Add mutex locking around the store's contents.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ import class Foundation.ProcessInfo
 let package = Package(
     name: "swift-opa",
     platforms: [
-        .macOS(.v13),
+        .macOS(.v15),
         .iOS(.v16),
     ],
     products: [

--- a/Sources/Rego/Store.swift
+++ b/Sources/Rego/Store.swift
@@ -1,4 +1,5 @@
 import AST
+import Synchronization
 
 extension OPA {
     /// An abstraction over a store providing keyed access to data used in policy evaluation.
@@ -13,8 +14,13 @@ extension OPA {
     }
 
     /// InMemoryStore is an in-memory implementation of ``OPA/Store``
-    public struct InMemoryStore {
-        private var data: AST.RegoValue = AST.RegoValue.object([:])
+    /// This has to be a public final class to implement ``Sendable`` properly.
+    public final class InMemoryStore: Sendable {
+        private let data: Mutex<AST.RegoValue>
+
+        public init(initialData data: AST.RegoValue = .object([:])) {
+            self.data = Mutex(data)
+        }
     }
 }
 
@@ -41,27 +47,24 @@ struct NullStore: OPA.Store {
 }
 
 extension OPA.InMemoryStore: OPA.Store {
-    public init(initialData data: AST.RegoValue) {
-        self.data = data
-    }
-
     public func read(from path: StoreKeyPath) async throws -> AST.RegoValue {
-        var current: AST.RegoValue = data
-        for segment in path.segments {
-            guard case .object(let object) = current else {
-                throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
+        return try self.data.withLock({
+            var current: AST.RegoValue = $0
+            for segment in path.segments {
+                guard case .object(let object) = current else {
+                    throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
+                }
+                guard let next = object[.string(segment)] else {
+                    throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
+                }
+                current = next
             }
-            guard let next = object[.string(segment)] else {
-                throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
-            }
-            current = next
-        }
 
-        return current
+            return current
+        })
     }
 
-    public mutating func write(to path: StoreKeyPath, value: AST.RegoValue) async throws {
-        // TODO this is not achieving our goal of thread safety
-        data = data.patch(with: value, at: path.segments)
+    public func write(to path: StoreKeyPath, value: AST.RegoValue) async throws {
+        self.data.withLock({ $0 = $0.patch(with: value, at: path.segments) })
     }
 }


### PR DESCRIPTION
### What code changed, and why?

This PR adds basic thread safety for the contents of the Rego Store with a non-recursive mutex lock around the RegoValue holding the store's contents.

Note: This only guards individual read and write ops, and there is no support yet for read or write transactions like we have in upstream OPA.

Known Hazard: Using `Mutex` forces us to upgrade to `macOS >= 15` in our supported platforms. Otherwise, we rapidly descend into a hellscape of trying to shim in a feature backport library, like [`swhitty/swift-mutex`](https://github.com/swhitty/swift-mutex). It can be done, but it's a non-trivial lift for all the conditional compilation stuff. 😓 

### Definition of done

 - [ ] Decide if we want to vendor/include a backport library for `Mutex` support on `macOS < 15` versions (e.g. `swhitty/swift-mutex`)
 - [ ] Test cases for concurrent store writes?

### How to test

 - Any future tests should get picked up in `make test`.

### Related Resources

 - [Synchronization Docs page for `Mutex`](https://developer.apple.com/documentation/synchronization/mutex)