### PR TITLE
perf: cache InvocationKey hash values at construction time

### DIFF
--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -12,6 +12,20 @@ let localIdxData = Local(1)
 struct InvocationKey: Hashable {
     let funcName: String
     let args: [IR.Operand]
+    private let cachedHashValue: Int
+
+    init(funcName: String, args: [IR.Operand]) {
+        self.funcName = funcName
+        self.args = args
+        var hasher = Hasher()
+        hasher.combine(funcName)
+        hasher.combine(args)
+        self.cachedHashValue = hasher.finalize()
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(cachedHashValue)
+    }
 }
 
 /// MemoCache is a memoization cache of plan invocations

--- a/Tests/RegoTests/IREvaluatorTests.swift
+++ b/Tests/RegoTests/IREvaluatorTests.swift
@@ -1210,3 +1210,49 @@ extension IRStatementTests.TestCase: CustomTestStringConvertible {
         return "\(mirror.subjectType): \(description)"
     }
 }
+
+@Test("InvocationKey hashing and equality")
+func invocationKeyHashingAndEquality() {
+    let args1: [IR.Operand] = [
+        IR.Operand(type: .local, value: .localIndex(0)),
+        IR.Operand(type: .local, value: .localIndex(1)),
+    ]
+    let args2: [IR.Operand] = [
+        IR.Operand(type: .local, value: .localIndex(0)),
+        IR.Operand(type: .local, value: .localIndex(1)),
+    ]
+
+    // Equal keys have equal hashes and compare equal
+    let a = InvocationKey(funcName: "g0.data.policy.allow", args: args1)
+    let b = InvocationKey(funcName: "g0.data.policy.allow", args: args2)
+    #expect(a == b)
+    #expect(a.hashValue == b.hashValue)
+
+    // Different funcName makes keys unequal
+    let c = InvocationKey(funcName: "g0.data.policy.deny", args: args1)
+    #expect(a != c)
+
+    // Different args make keys unequal
+    let args3: [IR.Operand] = [
+        IR.Operand(type: .local, value: .localIndex(0)),
+        IR.Operand(type: .local, value: .localIndex(2)),
+    ]
+    let d = InvocationKey(funcName: "g0.data.policy.allow", args: args3)
+    #expect(a != d)
+
+    // Different arg types make keys unequal
+    let args4: [IR.Operand] = [
+        IR.Operand(type: .bool, value: .bool(true)),
+        IR.Operand(type: .local, value: .localIndex(1)),
+    ]
+    let e = InvocationKey(funcName: "g0.data.policy.allow", args: args4)
+    #expect(a != e)
+
+    // Works correctly as dictionary keys (exercises hash + equality together)
+    var cache: [InvocationKey: AST.RegoValue] = [:]
+    cache[a] = .boolean(true)
+    cache[c] = .boolean(false)
+    #expect(cache[b] == .boolean(true), "Equal key should retrieve the same cached value")
+    #expect(cache[d] == nil, "Different key should not match")
+    #expect(cache.count == 2)
+}


### PR DESCRIPTION
### What code changed, and why?

Pre-compute and cache the hash value for `InvocationKey` when it is
constructed, rather than re-hashing funcName and args on every
dictionary lookup.

Why: `InvocationKey` is used as the key for the memoization cache
(`MemoCache`). Each memo lookup calls `hash(into:)`, which traverses
the `funcName` string and the entire args array of Operands. Since
`InvocationKey` is immutable (all let fields) and typically looked up
multiple times per construction, hashing the same data repeatedly is
pure overhead.

By computing the hash once in init() and returning it from
`hash(into:)`, dictionary lookups become O(1) integer operations
instead of O(n) string+array traversals.
