### PR TITLE
perf: reduce per-builtin-call overhead with context reuse and caching

### DIFF
--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -4,7 +4,7 @@ import Foundation
 public typealias Builtin = @Sendable (BuiltinContext, [AST.RegoValue]) async throws -> AST.RegoValue
 
 public struct BuiltinContext {
-    public let location: OPA.Trace.Location
+    public var location: OPA.Trace.Location
     public var tracer: OPA.Trace.QueryTracer?
     /// Date and Time of Context creation
     public let timestamp: Date
@@ -12,7 +12,6 @@ public struct BuiltinContext {
     internal let rand: Ptr<RandomNumberGenerator>
 
     init(
-
         location: OPA.Trace.Location = .init(),
         tracer: OPA.Trace.QueryTracer? = nil,
         cache: Ptr<BuiltinsCache>? = nil,

--- a/Sources/Rego/Evaluator.swift
+++ b/Sources/Rego/Evaluator.swift
@@ -19,6 +19,8 @@ internal struct EvaluationContext {
     public let timestamp: Date
     /// Shared cache for builtin function calls
     public let builtinsCache: Ptr<BuiltinsCache>
+    /// Shared random number generator for builtin function calls
+    public let builtinsRand: Ptr<RandomNumberGenerator>
 
     init(
         query: String,
@@ -37,6 +39,7 @@ internal struct EvaluationContext {
         self.strictBuiltins = strictBuiltins
         self.timestamp = timestamp ?? Date()
         self.builtinsCache = Ptr<BuiltinsCache>(toCopyOf: BuiltinsCache())
+        self.builtinsRand = Ptr<RandomNumberGenerator>(toCopyOf: SystemRandomNumberGenerator())
     }
 }
 

--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -171,11 +171,24 @@ internal final class IREvaluationContext {
     // Pool for reusing args arrays
     private var argsPool: [[AST.RegoValue]] = []
 
+    // Reusable builtin context — only location changes per call
+    var builtinContext: BuiltinContext
+
+    // Inline cache for resolved builtin function pointers, avoiding
+    // repeated Dictionary lookups on the BuiltinRegistry per call.
+    private var builtinCache: [String: Builtin] = [:]
+
     init(ctx: EvaluationContext, policy: IndexedIRPolicy) {
         self.ctx = ctx
         self.policy = policy
         self.tracingEnabled = ctx.tracer != nil
         self.results = ResultSet.empty
+        self.builtinContext = BuiltinContext(
+            tracer: ctx.tracer,
+            cache: ctx.builtinsCache,
+            timestamp: ctx.timestamp,
+            rand: ctx.builtinsRand
+        )
     }
 
     subscript(key: InvocationKey) -> AST.RegoValue? {
@@ -273,6 +286,18 @@ internal final class IREvaluationContext {
     func releaseArgs(_ args: inout [AST.RegoValue]) {
         args.removeAll(keepingCapacity: true)
         argsPool.append(args)
+    }
+
+    /// Resolve a builtin function by name, caching the result for future lookups.
+    func resolveBuiltin(name: String) -> Builtin? {
+        if let cached = builtinCache[name] {
+            return cached
+        }
+        if let builtin = ctx.builtins[name] {
+            builtinCache[name] = builtin
+            return builtin
+        }
+        return nil
     }
 
     func traceEvent(
@@ -1018,19 +1043,26 @@ private func evalCall(
         }
     }
 
-    let bctx = BuiltinContext(
-        location: try ctx.currentLocation(stmt: caller),
-        tracer: ctx.ctx.tracer,
-        cache: ctx.ctx.builtinsCache,
-        timestamp: ctx.ctx.timestamp
-    )
+    // Reuse the cached BuiltinContext, only updating location when tracing is enabled
+    if ctx.tracingEnabled {
+        ctx.builtinContext.location = try ctx.currentLocation(stmt: caller)
+    }
 
-    return try await ctx.ctx.builtins.invoke(
-        withContext: bctx,
-        name: funcName,
-        args: argValues,
-        strict: ctx.ctx.strictBuiltins
-    )
+    // Use cached builtin lookup to avoid repeated Dictionary lookups
+    guard let builtin = ctx.resolveBuiltin(name: funcName) else {
+        throw BuiltinRegistry.RegistryError.builtinNotFound(name: funcName)
+    }
+    do {
+        return try await builtin(ctx.builtinContext, argValues)
+    } catch {
+        if BuiltinError.isHaltError(error) {
+            throw error
+        }
+        if ctx.ctx.strictBuiltins {
+            throw error
+        }
+        return .undefined
+    }
 }
 
 // callPlanFunc will evaluate calling a function defined on the plan


### PR DESCRIPTION
### What code changed, and why?

Eliminate repeated allocation and lookup overhead on every builtin
function call during IR evaluation.

Changes:
1. Reuse BuiltinContext across calls
   Instead of allocating a new BuiltinContext struct per builtin call
   (with Date, cache pointer, tracer, RNG), create one at evaluation
   start and reuse it. Only the location field is updated, and only
   when tracing is enabled.
   Requires: BuiltinContext.location changed from let to var.

2. Cache resolved builtin function pointers
   Add an inline cache mapping builtin names to function pointers.
   After the first Dictionary lookup on the registry, subsequent calls
   to the same builtin skip the registry entirely.
   Also inlines the invoke() error handling to avoid the extra method
   call and its associated argument passing.

3. Share RNG via EvaluationContext
   Move the RandomNumberGenerator to EvaluationContext.builtinsRand
   so it is allocated once per evaluation and shared through the
   reusable BuiltinContext.
