### PR TITLE
deps: Bump swift-crypto to pick up newer APIs.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
## What changed?

This PR changes our [`swift-crypto`](https://github.com/apple/swift-crypto) dependency to automatically pick up newer versions of the package, up to the next major version (previously we stopped short of 4.0.0, now we stop short of 5.0.0).

This picks up all major changes made in the 4.0.0 version of the package, along with Swift 6 modernizations.

I learned about the "all up to the next major version" trick from the [swift-biscuit](https://github.com/eclipse-biscuit/biscuit-swift/blob/main/Package.swift#L20) repo's `Package.swift`