### PR TITLE
ComplianceTests: Override package name for local Swift OPA dep.

### DIFF
--- a/ComplianceSuite/Package.swift
+++ b/ComplianceSuite/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             targets: ["RegoCompliance"])
     ],
     dependencies: [
-        .package(path: swiftOpaDependencyPath)
+        .package(name: "swift-opa", path: swiftOpaDependencyPath)
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
### What code changed, and why?

This PR overrides the package name for the local Swift OPA dependency the test suite pulls in. This ensures that regardless of of the folder name on disk, we load it up under the correct package name, so the tests will build and run.

Before this change, if one had both "swift-opa" and "swift-opa-myfork" folders on disk, the "-myfork" folder's Compliance tests would error on build.

### How to test

 - Do the compliance test targets still work in CI?
 - Locally: Run `make test-compliance`
   - Try cloning the repo down under a folder name other than just `swift-opa`, and see if `make test-compliance` still works. On this PR, it should work fine.

### Related Resources

