### PR TITLE
perf: optimize string builtins with utf8 byte compare

### DIFF
--- a/Sources/Rego/Builtins/Strings.swift
+++ b/Sources/Rego/Builtins/Strings.swift
@@ -59,7 +59,57 @@ extension BuiltinFuncs {
         if needle.isEmpty {
             return .boolean(true)
         }
-        return .boolean(haystack.contains(needle))
+        // Use byte-level comparison (no Unicode normalization),
+        // matching Go's strings.Contains() semantics.
+        return .boolean(utf8Contains(haystack: haystack, needle: needle))
+    }
+
+    /// Byte-level substring search on raw UTF-8 buffers using `memcmp`.
+    /// Semantically identical to Go's `strings.Contains()` → `bytealg.IndexString()`.
+    private static func utf8Contains(haystack: String, needle: String) -> Bool {
+        let needleCount = needle.utf8.count
+        let haystackCount = haystack.utf8.count
+        if needleCount > haystackCount {
+            return false
+        }
+
+        // Fast path: contiguous UTF-8 storage (nearly always available for native Swift strings)
+        if let result = haystack.utf8.withContiguousStorageIfAvailable({ hBuf in
+            needle.utf8.withContiguousStorageIfAvailable({ nBuf in
+                utf8ContainsBytes(hBuf, nBuf)
+            })
+        }), let inner = result {
+            return inner
+        }
+
+        // Fallback: copy to contiguous arrays
+        // (still faster than the Foundation String.range(of:) path)
+        return Array(haystack.utf8).withUnsafeBufferPointer { hBuf in
+            Array(needle.utf8).withUnsafeBufferPointer { nBuf in
+                utf8ContainsBytes(hBuf, nBuf)
+            }
+        }
+    }
+
+    /// Scans `haystack` for `needle` using `memcmp` at each candidate position.
+    private static func utf8ContainsBytes(
+        _ haystack: UnsafeBufferPointer<UInt8>,
+        _ needle: UnsafeBufferPointer<UInt8>
+    ) -> Bool {
+        let hLen = haystack.count
+        let nLen = needle.count
+        guard nLen <= hLen, let hBase = haystack.baseAddress, let nBase = needle.baseAddress else {
+            return false
+        }
+        let firstByte = nBase.pointee
+        let limit = hLen - nLen
+        for i in 0...limit {
+            // Quick first-byte check to skip memcmp for most positions
+            if hBase[i] == firstByte && memcmp(hBase + i, nBase, nLen) == 0 {
+                return true
+            }
+        }
+        return false
     }
 
     static func stringsCount(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
@@ -97,7 +147,30 @@ extension BuiltinFuncs {
             throw BuiltinError.argumentTypeMismatch(arg: "base", got: args[1].typeName, want: "string")
         }
 
-        return .boolean(search.hasSuffix(base))
+        // Use UTF-8 byte-level comparison, matching Go's strings.HasSuffix() semantics.
+        if base.isEmpty {
+            return .boolean(true)
+        }
+        let baseCount = base.utf8.count
+        let searchCount = search.utf8.count
+        if baseCount > searchCount {
+            return .boolean(false)
+        }
+
+        // Fast path: contiguous memcmp
+        if let result = search.utf8.withContiguousStorageIfAvailable({ sBuf in
+            base.utf8.withContiguousStorageIfAvailable({ bBuf in
+                guard let sBase = sBuf.baseAddress, let bBase = bBuf.baseAddress else {
+                    return false
+                }
+                return memcmp(sBase + (sBuf.count - bBuf.count), bBase, bBuf.count) == 0
+            })
+        }), let inner = result {
+            return .boolean(inner)
+        }
+
+        // Fallback
+        return .boolean(search.utf8.suffix(baseCount).elementsEqual(base.utf8))
     }
 
     static func formatInt(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
@@ -280,7 +353,8 @@ extension BuiltinFuncs {
             throw BuiltinError.argumentTypeMismatch(arg: "base", got: args[1].typeName, want: "string")
         }
 
-        return .boolean(search.hasPrefix(base))
+        // Use UTF-8 byte-level comparison, matching Go's strings.HasPrefix() semantics.
+        return .boolean(search.utf8.starts(with: base.utf8))
     }
 
     static func substring(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {

--- a/Tests/RegoTests/BuiltinTests/StringsTests.swift
+++ b/Tests/RegoTests/BuiltinTests/StringsTests.swift
@@ -186,6 +186,98 @@ extension BuiltinTests.StringsTests {
             args: [1, "hello, world!"],
             expected: .failure(BuiltinError.argumentTypeMismatch(arg: "haystack", got: "number", want: "string"))
         ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 emoji",
+            name: "contains",
+            args: ["hello \u{1F600} world", "\u{1F600}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 CJK",
+            name: "contains",
+            args: ["\u{4F60}\u{597D}\u{4E16}\u{754C}", "\u{4E16}\u{754C}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "single character needle found",
+            name: "contains",
+            args: ["abcdef", "d"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "single character needle not found",
+            name: "contains",
+            args: ["abcdef", "z"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "needle at start",
+            name: "contains",
+            args: ["hello world", "hello"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "needle at end",
+            name: "contains",
+            args: ["hello world", "world"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "repeated pattern finds first",
+            name: "contains",
+            args: ["abcabcabc", "cab"],
+            expected: .success(true)
+        ),
+        // Unicode normalization: precomposed é (U+00E9) vs decomposed e + combining accent (U+0301).
+        // Go does byte-level comparison with no normalization, so these must NOT match.
+        BuiltinTests.TestCase(
+            description: "normalization mismatch: precomposed haystack, decomposed needle",
+            name: "contains",
+            args: ["caf\u{00E9}", "e\u{0301}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "normalization mismatch: decomposed haystack, precomposed needle",
+            name: "contains",
+            args: ["cafe\u{0301}", "\u{00E9}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "precomposed accent matches same bytes",
+            name: "contains",
+            args: ["caf\u{00E9}", "\u{00E9}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "decomposed accent matches same bytes",
+            name: "contains",
+            args: ["cafe\u{0301}", "e\u{0301}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "emoji not found",
+            name: "contains",
+            args: ["hello world", "\u{1F600}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "case sensitive mismatch",
+            name: "contains",
+            args: ["Hello World", "hello"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte needle longer than haystack",
+            name: "contains",
+            args: ["\u{1F600}", "\u{1F600}\u{1F601}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "haystack is needle repeated",
+            name: "contains",
+            args: ["aaa", "a"],
+            expected: .success(true)
+        ),
     ]
 
     static let endsWithTests: [BuiltinTests.TestCase] = [
@@ -260,6 +352,80 @@ extension BuiltinTests.StringsTests {
             name: "endswith",
             args: [1, "hello, world!"],
             expected: .failure(BuiltinError.argumentTypeMismatch(arg: "search", got: "number", want: "string"))
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 emoji suffix",
+            name: "endswith",
+            args: ["hello \u{1F600}", "\u{1F600}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 emoji suffix not found",
+            name: "endswith",
+            args: ["hello \u{1F600}", "\u{1F601}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 CJK suffix",
+            name: "endswith",
+            args: ["\u{4F60}\u{597D}\u{4E16}\u{754C}", "\u{4E16}\u{754C}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 CJK suffix not found",
+            name: "endswith",
+            args: ["\u{4F60}\u{597D}\u{4E16}\u{754C}", "\u{4E16}\u{754C}\u{FF01}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "single character suffix found",
+            name: "endswith",
+            args: ["abcdef", "f"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "single character suffix not found",
+            name: "endswith",
+            args: ["abcdef", "a"],
+            expected: .success(false)
+        ),
+        // Unicode normalization: precomposed é (U+00E9) vs decomposed e + combining accent (U+0301).
+        // Go does byte-level comparison with no normalization, so these must NOT match.
+        BuiltinTests.TestCase(
+            description: "normalization mismatch: precomposed search, decomposed base",
+            name: "endswith",
+            args: ["caf\u{00E9}", "e\u{0301}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "normalization mismatch: decomposed search, precomposed base",
+            name: "endswith",
+            args: ["cafe\u{0301}", "\u{00E9}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "precomposed accent matches same bytes",
+            name: "endswith",
+            args: ["caf\u{00E9}", "f\u{00E9}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "decomposed accent matches same bytes",
+            name: "endswith",
+            args: ["cafe\u{0301}", "e\u{0301}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "case sensitive suffix mismatch",
+            name: "endswith",
+            args: ["Hello World", "WORLD"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "suffix is entire string with emoji",
+            name: "endswith",
+            args: ["\u{1F600}\u{1F601}", "\u{1F600}\u{1F601}"],
+            expected: .success(true)
         ),
     ]
 
@@ -790,6 +956,110 @@ extension BuiltinTests.StringsTests {
             description: "both empty",
             name: "startswith",
             args: ["", ""],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "too many args",
+            name: "startswith",
+            args: ["hello, world!", "hello", "extra"],
+            expected: .failure(BuiltinError.argumentCountMismatch(got: 3, want: 2))
+        ),
+        BuiltinTests.TestCase(
+            description: "not enough args",
+            name: "startswith",
+            args: ["hello, world!"],
+            expected: .failure(BuiltinError.argumentCountMismatch(got: 1, want: 2))
+        ),
+        BuiltinTests.TestCase(
+            description: "no args",
+            name: "startswith",
+            args: [],
+            expected: .failure(BuiltinError.argumentCountMismatch(got: 0, want: 2))
+        ),
+        BuiltinTests.TestCase(
+            description: "wrong type base",
+            name: "startswith",
+            args: ["hello, world!", 1],
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "base", got: "number", want: "string"))
+        ),
+        BuiltinTests.TestCase(
+            description: "wrong type search",
+            name: "startswith",
+            args: [1, "hello, world!"],
+            expected: .failure(BuiltinError.argumentTypeMismatch(arg: "search", got: "number", want: "string"))
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 emoji prefix",
+            name: "startswith",
+            args: ["\u{1F600} hello", "\u{1F600}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 emoji prefix not found",
+            name: "startswith",
+            args: ["\u{1F600} hello", "\u{1F601}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 CJK prefix",
+            name: "startswith",
+            args: ["\u{4F60}\u{597D}\u{4E16}\u{754C}", "\u{4F60}\u{597D}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "multi-byte UTF-8 CJK prefix not found",
+            name: "startswith",
+            args: ["\u{4F60}\u{597D}\u{4E16}\u{754C}", "\u{4E16}\u{754C}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "single character prefix found",
+            name: "startswith",
+            args: ["abcdef", "a"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "single character prefix not found",
+            name: "startswith",
+            args: ["abcdef", "z"],
+            expected: .success(false)
+        ),
+        // Unicode normalization: precomposed é (U+00E9) vs decomposed e + combining accent (U+0301).
+        // Go does byte-level comparison with no normalization, so these must NOT match.
+        BuiltinTests.TestCase(
+            description: "normalization mismatch: precomposed search, decomposed base",
+            name: "startswith",
+            args: ["\u{00E9}lan", "e\u{0301}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "normalization mismatch: decomposed search, precomposed base",
+            name: "startswith",
+            args: ["e\u{0301}lan", "\u{00E9}"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "precomposed accent matches same bytes",
+            name: "startswith",
+            args: ["\u{00E9}lan", "\u{00E9}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "decomposed accent matches same bytes",
+            name: "startswith",
+            args: ["e\u{0301}lan", "e\u{0301}"],
+            expected: .success(true)
+        ),
+        BuiltinTests.TestCase(
+            description: "case sensitive prefix mismatch",
+            name: "startswith",
+            args: ["Hello World", "hello"],
+            expected: .success(false)
+        ),
+        BuiltinTests.TestCase(
+            description: "prefix is entire string with emoji",
+            name: "startswith",
+            args: ["\u{1F600}\u{1F601}", "\u{1F600}\u{1F601}"],
             expected: .success(true)
         ),
     ]


### PR DESCRIPTION
### What code changed, and why?

Optimizes `strings.contains`, `strings.endswith`, and `strings.startswith` builtins to use direct UTF-8 byte comparison (`memcmp`) instead of Swift's default String methods. 


This matches Go's `strings.Contains`/`HasPrefix`/`HasSuffix` semantics - raw byte comparison with no Unicode normalization - and improves performance by avoiding Foundation overhead. 

Added a comprehensive test suite covering multi-byte UTF-8 (emoji, CJK), Unicode normalization edge cases, error handling, and boundary conditions.