### PR TITLE
ci(perf): Refactor benchmarks to run in CI, and add memo benchmark

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,173 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to benchmark against its base"
+        type: number
+        required: true
+      debug_benchmarks:
+        description: "Print benchmark results for debugging"
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: benchmark comparison (vs base)
+    runs-on: ubuntu-latest
+    # use swift upstream images to stay on the latest GA version
+    container: swift:noble
+    continue-on-error: true
+    env:
+      BENCHMARK_MAX_DURATION_SECONDS: "3"
+      BENCHMARK_WARMUP_ITERATIONS: "100"
+    permissions:
+      contents: read
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Detect Swift version
+        id: swift
+        run: echo "version=$(swift --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
+        # jemalloc may eventually go away after swift 6.3.0 GAs due to https://github.com/ordo-one/package-benchmark/pull/333
+      - name: Install jemalloc and zstd for cache
+        run: |
+          apt-get update -q
+          apt-get install -yq libjemalloc-dev zstd jq curl
+      - name: Resolve PR refs
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PR_JSON=$(curl -sf \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GH_REPO}/pulls/${{ inputs.pr_number }}")
+          echo "base_sha=$(echo "$PR_JSON" | jq -r .base.sha)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(echo "$PR_JSON" | jq -r .head.sha)" >> "$GITHUB_OUTPUT"
+      - name: Checkout base branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.base_sha }}
+          path: base
+          persist-credentials: false
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          path: pr
+          persist-credentials: false
+      - name: Restore .build cache
+        id: build-cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            base/Benchmarks/.build
+            pr/Benchmarks/.build
+          key: benchmark-build-swift${{ steps.swift.outputs.version }}-${{ steps.pr.outputs.base_sha }}
+          restore-keys: benchmark-build-swift${{ steps.swift.outputs.version }}-
+      - name: Restore baseline results cache
+        id: baseline-cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: base/Benchmarks/.benchmarkBaselines
+          key: benchmark-baseline-swift${{ steps.swift.outputs.version }}-${{ steps.pr.outputs.base_sha }}
+      - name: Run benchmarks on base and save baseline
+        if: steps.baseline-cache.outputs.cache-hit != 'true'
+        run: |
+          swift package -c release --disable-sandbox \
+            --package-path Benchmarks \
+            benchmark baseline update base \
+            --no-progress
+        working-directory: base
+      - name: Print base benchmark results
+        if: inputs.debug_benchmarks == true
+        run: |
+          swift package -c release --disable-sandbox \
+            --package-path Benchmarks \
+            benchmark baseline read base \
+            --no-progress
+        working-directory: base
+      - name: Copy baseline to PR checkout
+        run: cp -R base/Benchmarks/.benchmarkBaselines pr/Benchmarks/.benchmarkBaselines
+      - name: Run benchmarks on PR and save baseline
+        run: |
+          swift package -c release --disable-sandbox \
+            --package-path Benchmarks \
+            benchmark baseline update pr \
+            --no-progress
+        working-directory: pr
+      - name: Print PR benchmark results
+        if: inputs.debug_benchmarks == true
+        run: |
+          swift package -c release --disable-sandbox \
+            --package-path Benchmarks \
+            benchmark baseline read pr \
+            --no-progress
+        working-directory: pr
+      - name: Compare PR benchmarks against baseline
+        id: compare
+        run: |
+          set +e
+          swift package -c release --disable-sandbox \
+            --package-path Benchmarks \
+            benchmark baseline compare base pr \
+            --no-progress \
+            --format markdown \
+            2>/dev/null \
+            | tee benchmark-comparison.md
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+          case "${EXIT_CODE}" in
+            0) SUMMARY="✅ No significant performance changes" ;;
+            2) SUMMARY="❌ Potential performance regression detected 📉" ;;
+            4) SUMMARY="⚠️ Performance improvement detected 📈" ;;
+            *) SUMMARY="❓ Benchmark comparison completed (exit code: ${EXIT_CODE})" ;;
+          esac
+          echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "comparison<<EOF"
+            cat benchmark-comparison.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        working-directory: pr
+      - name: Find existing benchmark comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: find-comment
+        with:
+          issue-number: ${{ inputs.pr_number }}
+          body-includes: "<!-- benchmark-comparison -->"
+      - name: Post PR comment
+        continue-on-error: true
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ inputs.pr_number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- benchmark-comparison -->
+            ## Benchmark Comparison
+
+            ${{ steps.compare.outputs.summary }}
+
+            <details>
+              <summary>Full comparison output</summary>
+
+            ${{ steps.compare.outputs.comparison }}
+
+            </details>

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-opa", path: ".."),
-        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.4.0"),
+        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.31.0"),
     ],
     targets: [
         .executableTarget(

--- a/Benchmarks/Sources/RegoBenchmarks.swift
+++ b/Benchmarks/Sources/RegoBenchmarks.swift
@@ -3,263 +3,153 @@ import Benchmark
 import Foundation
 internal import Rego
 
+struct BenchmarkSpec {
+    let name: String
+    let bundleName: String
+    let bundlePath: String
+    let query: String
+    let input: AST.RegoValue
+}
+
+// Bundle paths are relative to the Benchmarks directory
+let bundlesPath = "../Tests/RegoTests/TestData/Bundles"
+
+let allBenchmarkSpecs: [BenchmarkSpec] =
+    [
+        // MARK: - Policy Evaluation
+        BenchmarkSpec(
+            name: "Simple Policy Evaluation",
+            bundleName: "simple",
+            bundlePath: "simple-directory-bundle",
+            query: "data.app.rbac.allow",
+            input: [
+                "user": "alice",
+                "action": "read",
+                "resource": "document123",
+            ]
+        ),
+
+        // MARK: - Dynamic Calls
+        BenchmarkSpec(
+            name: "Dynamic Call - Double",
+            bundleName: "dynamic",
+            bundlePath: "dynamic-call-bundle",
+            query: "data.test",
+            input: [
+                "operation": "double",
+                "value": 42,
+            ]
+        ),
+        BenchmarkSpec(
+            name: "Dynamic Call - Square",
+            bundleName: "dynamic",
+            bundlePath: "dynamic-call-bundle",
+            query: "data.test",
+            input: [
+                "operation": "square",
+                "value": 42,
+            ]
+        ),
+
+        // MARK: - Numeric Literals
+        BenchmarkSpec(
+            name: "Numeric Literals",
+            bundleName: "numeric",
+            bundlePath: "numeric-literals-bundle",
+            query: "data.benchmark.numeric",
+            input: [
+                "value": 10,
+                "bonus": 5.5,
+                "multiplier": 2.0,
+            ]
+        ),
+
+        // MARK: - Collection Building
+        BenchmarkSpec(
+            name: "Build Literal Array (10 appends)",
+            bundleName: "array",
+            bundlePath: "array-build-bundle",
+            query: "data.benchmark.array.matched",
+            input: ["value": "/bin/nomatch"]
+        ),
+        BenchmarkSpec(
+            name: "Build Literal Object (10 inserts)",
+            bundleName: "object",
+            bundlePath: "object-build-bundle",
+            query: "data.benchmark.object.matched",
+            input: ["value": "__nomatch__"]
+        ),
+        BenchmarkSpec(
+            name: "Build Literal Set (10 adds)",
+            bundleName: "set",
+            bundlePath: "set-build-bundle",
+            query: "data.benchmark.set.matched",
+            input: ["value": "__nomatch__"]
+        ),
+
+        // MARK: - Memoization
+        BenchmarkSpec(
+            name: "Memoization - Overlapping Rules",
+            bundleName: "memo",
+            bundlePath: "memo-benchmark",
+            query: "data.benchmark.memo.result",
+            input: ["value": 10]
+        ),
+    ]
+    // MARK: - Array Iteration (parameterized)
+    + [
+        ("Small (10 items)", 10, 5),
+        ("Medium (100 items)", 100, 50),
+        ("Large (1000 items)", 1000, 500),
+    ].map { (label, count, threshold) in
+        BenchmarkSpec(
+            name: "Array Iteration - \(label)",
+            bundleName: "iteration",
+            bundlePath: "array-iteration-bundle",
+            query: "data.benchmark.iteration",
+            input: [
+                "items": .array((1...count).map { .number(RegoNumber(int: Int64($0))) }),
+                "threshold": .number(RegoNumber(int: Int64(threshold))),
+            ]
+        )
+    }
+
 let benchmarks: @Sendable () -> Void = {
     Benchmark.defaultConfiguration.timeUnits = .nanoseconds
 
-    // Benchmark runs from the Benchmarks directory, so paths are relative to parent
-    let simpleBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/simple-directory-bundle")
-    let dynamicCallBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/dynamic-call-bundle")
-    let arrayIterationBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/array-iteration-bundle")
-    let numericLiteralsBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/numeric-literals-bundle")
-    let arrayBuildBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/array-build-bundle")
-    let objectBuildBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/object-build-bundle")
-    let setBuildBundleURL = URL(fileURLWithPath: "../Tests/RegoTests/TestData/Bundles/set-build-bundle")
-
-    Benchmark(
-        "Simple Policy Evaluation",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        // Setup OPA engine
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "simple", url: simpleBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.app.rbac.allow")
-        } catch {}
-
-        let input: AST.RegoValue = [
-            "user": "alice",
-            "action": "read",
-            "resource": "document123",
-        ]
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: input)
-                blackHole(result)
-            } catch {}
-        }
+    if let maxDurationStr = ProcessInfo.processInfo.environment["BENCHMARK_MAX_DURATION_SECONDS"],
+        let seconds = Int(maxDurationStr)
+    {
+        Benchmark.defaultConfiguration.maxDuration = .seconds(seconds)
     }
 
-    Benchmark(
-        "Dynamic Call - Double",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        // Setup OPA engine
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "dynamic", url: dynamicCallBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.test")
-        } catch {}
-
-        let input: AST.RegoValue = [
-            "operation": "double",
-            "value": 42,
-        ]
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: input)
-                blackHole(result)
-            } catch {}
-        }
+    if let warmupStr = ProcessInfo.processInfo.environment["BENCHMARK_WARMUP_ITERATIONS"],
+        let iterations = Int(warmupStr)
+    {
+        Benchmark.defaultConfiguration.warmupIterations = iterations
     }
 
-    Benchmark(
-        "Dynamic Call - Square",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        // Setup OPA engine
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "dynamic", url: dynamicCallBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.test")
-        } catch {}
-
-        let input: AST.RegoValue = [
-            "operation": "square",
-            "value": 42,
-        ]
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
+    for spec in allBenchmarkSpecs {
+        let bundleURL = URL(fileURLWithPath: "\(bundlesPath)/\(spec.bundlePath)")
+        Benchmark(
+            spec.name,
+            configuration: .init(metrics: [.wallClock, .mallocCountTotal, .objectAllocCount, .instructions])
+        ) { benchmark in
+            var engine = OPA.Engine(
+                bundlePaths: [OPA.Engine.BundlePath(name: spec.bundleName, url: bundleURL)])
+            var preparedQuery: OPA.Engine.PreparedQuery?
             do {
-                let result = try await preparedQuery?.evaluate(input: input)
-                blackHole(result)
+                preparedQuery = try await engine.prepareForEvaluation(query: spec.query)
             } catch {}
-        }
-    }
 
-    Benchmark(
-        "Array Iteration - Small (10 items)",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        // Setup OPA engine
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "iteration", url: arrayIterationBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.benchmark.iteration")
-        } catch {}
-
-        let input: AST.RegoValue = [
-            "items": .array((1...10).map { .number(RegoNumber(int: Int64($0))) }),
-            "threshold": 5,
-        ]
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: input)
-                blackHole(result)
-            } catch {}
-        }
-    }
-
-    Benchmark(
-        "Array Iteration - Medium (100 items)",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        // Setup OPA engine
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "iteration", url: arrayIterationBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.benchmark.iteration")
-        } catch {}
-
-        let input: AST.RegoValue = [
-            "items": .array((1...100).map { .number(RegoNumber(int: Int64($0))) }),
-            "threshold": 50,
-        ]
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: input)
-                blackHole(result)
-            } catch {}
-        }
-    }
-
-    Benchmark(
-        "Array Iteration - Large (1000 items)",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        // Setup OPA engine
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "iteration", url: arrayIterationBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.benchmark.iteration")
-        } catch {}
-
-        let input: AST.RegoValue = [
-            "items": .array((1...1000).map { .number(RegoNumber(int: Int64($0))) }),
-            "threshold": 500,
-        ]
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: input)
-                blackHole(result)
-            } catch {}
-        }
-    }
-
-    Benchmark(
-        "Numeric Literals",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        // Setup OPA engine
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "numeric", url: numericLiteralsBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.benchmark.numeric")
-        } catch {}
-
-        let input: AST.RegoValue = [
-            "value": 10,
-            "bonus": 5.5,
-            "multiplier": 2.0,
-        ]
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: input)
-                blackHole(result)
-            } catch {}
-        }
-    }
-
-    let scanInput: AST.RegoValue = ["value": "/bin/nomatch"]
-
-    Benchmark(
-        "Build Literal Array (10 appends)",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "array", url: arrayBuildBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.benchmark.array.matched")
-        } catch {}
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: scanInput)
-                blackHole(result)
-            } catch {}
-        }
-    }
-
-    let collectionInput: AST.RegoValue = ["value": "__nomatch__"]
-
-    Benchmark(
-        "Build Literal Object (10 inserts)",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "object", url: objectBuildBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.benchmark.object.matched")
-        } catch {}
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: collectionInput)
-                blackHole(result)
-            } catch {}
-        }
-    }
-
-    Benchmark(
-        "Build Literal Set (10 adds)",
-        configuration: .init(metrics: [.wallClock, .mallocCountTotal])
-    ) { benchmark in
-        var engine = OPA.Engine(
-            bundlePaths: [OPA.Engine.BundlePath(name: "set", url: setBuildBundleURL)])
-        var preparedQuery: OPA.Engine.PreparedQuery?
-        do {
-            preparedQuery = try await engine.prepareForEvaluation(query: "data.benchmark.set.matched")
-        } catch {}
-
-        benchmark.startMeasurement()
-        for _ in benchmark.scaledIterations {
-            do {
-                let result = try await preparedQuery?.evaluate(input: collectionInput)
-                blackHole(result)
-            } catch {}
+            benchmark.startMeasurement()
+            for _ in benchmark.scaledIterations {
+                do {
+                    let result = try await preparedQuery?.evaluate(input: spec.input)
+                    blackHole(result)
+                } catch {}
+            }
+            benchmark.stopMeasurement()
         }
     }
 }

--- a/Tests/RegoTests/TestData/Bundles/memo-benchmark/.manifest
+++ b/Tests/RegoTests/TestData/Bundles/memo-benchmark/.manifest
@@ -1,0 +1,1 @@
+{"revision":"","roots":[""],"rego_version":1}

--- a/Tests/RegoTests/TestData/Bundles/memo-benchmark/plan.json
+++ b/Tests/RegoTests/TestData/Bundles/memo-benchmark/plan.json
@@ -1,0 +1,2994 @@
+{
+  "funcs": {
+    "funcs": [
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 5,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 5,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 5,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 2,
+                  "col": 12,
+                  "file": 0,
+                  "row": 5,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 5
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 5
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 5,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 5,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 5,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 5,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_1",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_1"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 7,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 7,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 7,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 3,
+                  "col": 12,
+                  "file": 0,
+                  "row": 7,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 7
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 7
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 7,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 7,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 7,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 7,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_2",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_2"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 9,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 9,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 9,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 4,
+                  "col": 12,
+                  "file": 0,
+                  "row": 9,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 9
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 9
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 9,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 9,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 9,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 9,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_3",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_3"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 11,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 11,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 11,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 5,
+                  "col": 12,
+                  "file": 0,
+                  "row": 11,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 11
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 11
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 11,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 11,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 11,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 11,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_4",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_4"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 13,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 13,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 13,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 6,
+                  "col": 12,
+                  "file": 0,
+                  "row": 13,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 13
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 13
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 13,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 13,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 13,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 13,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_5",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_5"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 27,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_1",
+                  "result": 4,
+                  "row": 28
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 28
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_2",
+                  "result": 5,
+                  "row": 29
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 5
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 29
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_3",
+                  "result": 6,
+                  "row": 30
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 6
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 30
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_4",
+                  "result": 7,
+                  "row": 31
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 31
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_5",
+                  "result": 8,
+                  "row": 32
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 8
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 32
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 27,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 27,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 27,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 27,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.composite_a",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "composite_a"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 15,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 15,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 15,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 7,
+                  "col": 12,
+                  "file": 0,
+                  "row": 15,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 15
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 15
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 15,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 15,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 15,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 15,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_6",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_6"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 17,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 17,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 17,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 8,
+                  "col": 12,
+                  "file": 0,
+                  "row": 17,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 17
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 17
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 17,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 17,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 17,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 17,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_7",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_7"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 35,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_3",
+                  "result": 4,
+                  "row": 36
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 36
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_4",
+                  "result": 5,
+                  "row": 37
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 5
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 37
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_5",
+                  "result": 6,
+                  "row": 38
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 6
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 38
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_6",
+                  "result": 7,
+                  "row": 39
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 39
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_7",
+                  "result": 8,
+                  "row": 40
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 8
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 40
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 35,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 35,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 35,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 35,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.composite_b",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "composite_b"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 19,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 19,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 19,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 9,
+                  "col": 12,
+                  "file": 0,
+                  "row": 19,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 19
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 19
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 19,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 19,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 19,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 19,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_8",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_8"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 21,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 21,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 12,
+                  "file": 0,
+                  "row": 21,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 10,
+                  "col": 12,
+                  "file": 0,
+                  "row": 21,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 12,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 21
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 12,
+                  "file": 0,
+                  "row": 21
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 21,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 21,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 21,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 21,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_9",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_9"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 43,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_5",
+                  "result": 4,
+                  "row": 44
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 44
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_6",
+                  "result": 5,
+                  "row": 45
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 5
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 45
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_7",
+                  "result": 6,
+                  "row": 46
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 6
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 46
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_8",
+                  "result": 7,
+                  "row": 47
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 47
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_9",
+                  "result": 8,
+                  "row": 48
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 8
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 48
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 43,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 43,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 43,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 43,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.composite_c",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "composite_c"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 23,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "col": 13,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 1
+                  },
+                  "row": 23,
+                  "source": {
+                    "type": "local",
+                    "value": 0
+                  },
+                  "target": 4
+                },
+                "type": "DotStmt"
+              },
+              {
+                "stmt": {
+                  "col": 13,
+                  "file": 0,
+                  "row": 23,
+                  "source": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "target": 5
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "Index": 11,
+                  "col": 13,
+                  "file": 0,
+                  "row": 23,
+                  "target": 6
+                },
+                "type": "MakeNumberRefStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 5
+                    },
+                    {
+                      "type": "local",
+                      "value": 6
+                    }
+                  ],
+                  "col": 13,
+                  "file": 0,
+                  "func": "gt",
+                  "result": 7,
+                  "row": 23
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 13,
+                  "file": 0,
+                  "row": 23
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 23,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 23,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 23,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 23,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.check_10",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "check_10"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 51,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_7",
+                  "result": 4,
+                  "row": 52
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 52
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_8",
+                  "result": 5,
+                  "row": 53
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 5
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 53
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_9",
+                  "result": 6,
+                  "row": 54
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 6
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 54
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_10",
+                  "result": 7,
+                  "row": 55
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 55
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.check_1",
+                  "result": 8,
+                  "row": 56
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 8
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 56
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 51,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 51,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 51,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 51,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.composite_d",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "composite_d"
+        ],
+        "return": 2
+      },
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 60,
+                  "target": 3
+                },
+                "type": "ResetLocalStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.composite_a",
+                  "result": 4,
+                  "row": 61
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 4
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 61
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.composite_b",
+                  "result": 5,
+                  "row": 62
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 5
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 62
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.composite_c",
+                  "result": 6,
+                  "row": 63
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 6
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 63
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 2,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.composite_d",
+                  "result": 7,
+                  "row": 64
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "a": {
+                    "type": "local",
+                    "value": 7
+                  },
+                  "b": {
+                    "type": "bool",
+                    "value": false
+                  },
+                  "col": 2,
+                  "file": 0,
+                  "row": 64
+                },
+                "type": "NotEqualStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 60,
+                  "source": {
+                    "type": "bool",
+                    "value": true
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 60,
+                  "source": 3
+                },
+                "type": "IsDefinedStmt"
+              },
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 60,
+                  "source": {
+                    "type": "local",
+                    "value": 3
+                  },
+                  "target": 2
+                },
+                "type": "AssignVarOnceStmt"
+              }
+            ]
+          },
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "col": 1,
+                  "file": 0,
+                  "row": 60,
+                  "source": 2
+                },
+                "type": "ReturnLocalStmt"
+              }
+            ]
+          }
+        ],
+        "name": "g0.data.benchmark.memo.result",
+        "params": [
+          0,
+          1
+        ],
+        "path": [
+          "g0",
+          "benchmark",
+          "memo",
+          "result"
+        ],
+        "return": 2
+      }
+    ]
+  },
+  "plans": {
+    "plans": [
+      {
+        "blocks": [
+          {
+            "stmts": [
+              {
+                "stmt": {
+                  "args": [
+                    {
+                      "type": "local",
+                      "value": 0
+                    },
+                    {
+                      "type": "local",
+                      "value": 1
+                    }
+                  ],
+                  "col": 0,
+                  "file": 0,
+                  "func": "g0.data.benchmark.memo.result",
+                  "result": 2,
+                  "row": 0
+                },
+                "type": "CallStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "row": 0,
+                  "source": {
+                    "type": "local",
+                    "value": 2
+                  },
+                  "target": 3
+                },
+                "type": "AssignVarStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "row": 0,
+                  "target": 4
+                },
+                "type": "MakeObjectStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "key": {
+                    "type": "string_index",
+                    "value": 0
+                  },
+                  "object": 4,
+                  "row": 0,
+                  "value": {
+                    "type": "local",
+                    "value": 3
+                  }
+                },
+                "type": "ObjectInsertStmt"
+              },
+              {
+                "stmt": {
+                  "col": 0,
+                  "file": 0,
+                  "row": 0,
+                  "value": 4
+                },
+                "type": "ResultSetAddStmt"
+              }
+            ]
+          }
+        ],
+        "name": "benchmark/memo/result"
+      }
+    ]
+  },
+  "static": {
+    "builtin_funcs": [
+      {
+        "decl": {
+          "args": [
+            {
+              "name": "x",
+              "type": "any"
+            },
+            {
+              "name": "y",
+              "type": "any"
+            }
+          ],
+          "result": {
+            "description": "true if `x` is greater than `y`; false otherwise",
+            "name": "result",
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "name": "gt"
+      }
+    ],
+    "files": [
+      {
+        "value": "policy.rego"
+      }
+    ],
+    "strings": [
+      {
+        "value": "result"
+      },
+      {
+        "value": "value"
+      },
+      {
+        "value": "0"
+      },
+      {
+        "value": "1"
+      },
+      {
+        "value": "2"
+      },
+      {
+        "value": "3"
+      },
+      {
+        "value": "4"
+      },
+      {
+        "value": "5"
+      },
+      {
+        "value": "6"
+      },
+      {
+        "value": "7"
+      },
+      {
+        "value": "8"
+      },
+      {
+        "value": "9"
+      }
+    ]
+  }
+}

--- a/Tests/RegoTests/TestData/Bundles/memo-benchmark/policy.rego
+++ b/Tests/RegoTests/TestData/Bundles/memo-benchmark/policy.rego
@@ -1,0 +1,65 @@
+package benchmark.memo
+
+# 10 check rules - each performs a simple comparison against input.
+# These become separate IR functions that are memoizable (2-arg calls).
+check_1 if input.value > 0
+
+check_2 if input.value > 1
+
+check_3 if input.value > 2
+
+check_4 if input.value > 3
+
+check_5 if input.value > 4
+
+check_6 if input.value > 5
+
+check_7 if input.value > 6
+
+check_8 if input.value > 7
+
+check_9 if input.value > 8
+
+check_10 if input.value > 9
+
+# 4 composite rules reference overlapping subsets of check rules.
+# This creates ~20 check calls with ~10 memo cache hits per evaluation.
+composite_a if {
+	check_1
+	check_2
+	check_3
+	check_4
+	check_5
+}
+
+composite_b if {
+	check_3
+	check_4
+	check_5
+	check_6
+	check_7
+}
+
+composite_c if {
+	check_5
+	check_6
+	check_7
+	check_8
+	check_9
+}
+
+composite_d if {
+	check_7
+	check_8
+	check_9
+	check_10
+	check_1
+}
+
+# Entrypoint that evaluates all composites
+result if {
+	composite_a
+	composite_b
+	composite_c
+	composite_d
+}


### PR DESCRIPTION
### What code changed, and why?

This PR does the following:
* Refactors the benchmarks file to be a bit more DRY and adds two tuning knobs to help de-noise automated benchmarks at runtime.
* Adds a memoization benchmark for overlapping rules
* Introduces a github pipeline to run differential PR benchmarks which posts and updates a comment in the PR with detailed run information [example comment/pr](https://github.com/arirubinstein/swift-opa/pull/3)
* Bumps benchmark dependency to 1.31.0 to pick up jemalloc flags and linux fixes

Notes:
jemalloc in github runners are problematic, so I introduced ARC allocations as a proxy (which coincidentally the swift benchmark framework uses as a proxy when jemalloc doesn't work)

### How to test
`make perf`


