### PR TITLE
Rego/Bundle: Add public inits for Bundle, BundleFile, and Manifest.

### DIFF
--- a/Sources/Rego/Bundle.swift
+++ b/Sources/Rego/Bundle.swift
@@ -120,4 +120,9 @@ public struct BundleFile: Sendable, Hashable {
     public let url: URL  // relative to bundle root
     /// The raw file contents.
     public let data: Data
+
+    public init(url: URL, data: Data) {
+        self.url = url
+        self.data = data
+    }
 }

--- a/Sources/Rego/Bundle.swift
+++ b/Sources/Rego/Bundle.swift
@@ -31,11 +31,21 @@ extension OPA {
             case regoV0 = 0
             case regoV1 = 1
         }
+
+        public init(
+            revision: String = "", roots: [String] = [""], regoVersion: Version = .regoV1,
+            metadata: AST.RegoValue = .null
+        ) {
+            self.revision = revision
+            self.roots = roots
+            self.regoVersion = regoVersion
+            self.metadata = metadata
+        }
     }
 }
 
 extension OPA.Bundle {
-    init(
+    public init(
         manifest: OPA.Manifest = OPA.Manifest(), planFiles: [BundleFile] = [], regoFiles: [BundleFile] = [],
         data: AST.RegoValue = .object([:])
     ) throws(BundleError) {
@@ -56,7 +66,7 @@ extension OPA.Bundle {
         self.rootsTrie = trie
     }
 
-    enum BundleError: Swift.Error {
+    public enum BundleError: Swift.Error {
         case overlappingRoots(String)
         case internalError(String)
     }


### PR DESCRIPTION
### What code changed, and why?

This PR adds a public init method for the `Bundle`, `BundleFile`, and `Manifest` types, allowing users to construct `Bundle` and `BundleLoader` systems outside of this library.

The motivation for this change is that it was possible to see the public `BundleFile` type, but it was impossible to construct an instance of it outside of the library due to the [default compiler-synthesized init method having `internal` scoping](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0018-flexible-memberwise-initialization.md#impact-on-existing-code) (which behaves like `private` scope to outside viewers).

This meant that users of Swift OPA could not create their own bundle loaders or otherwise assemble a bundle from its component pieces outside of the limited methods provided by the library.

### How to test

 - Tests and CI should continue to pass here.
 - Downstream users (which could someday include our `Benchmarks` and `ComplianceTests` sub-projects in this repo) should be able to construct `BundleFile` and `Bundle` instances directly with the public init methods available.

### Related Resources

 - Original language change proposal from Chris Lattner to add the compiler-synthesized default initializers: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0018-flexible-memberwise-initialization.md
