### PR TITLE
builtins: implement time.add_date

### DIFF
--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -158,6 +158,7 @@ public struct BuiltinRegistry: Sendable {
             "internal.template_string": BuiltinFuncs.templateString,
 
             // Time
+            "time.add_date": BuiltinFuncs.timeAddDate,
             "time.now_ns": BuiltinFuncs.timeNowNanos,
 
             // Trace

--- a/Sources/Rego/Builtins/Time.swift
+++ b/Sources/Rego/Builtins/Time.swift
@@ -1,6 +1,9 @@
 import AST
 import Foundation
 
+private let minDateAllowedForNsConversion = Date(timeIntervalSince1970: TimeInterval(Int64.min) / 1_000_000_000)
+private let maxDateAllowedForNsConversion = Date(timeIntervalSince1970: TimeInterval(Int64.max) / 1_000_000_000)
+
 extension BuiltinFuncs {
     static func timeNowNanos(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 0 else {
@@ -9,8 +12,81 @@ extension BuiltinFuncs {
         // Note that the value of the "now" is pinned to the value in the BuiltinContext.
         // This is done so that multiple calls to this built-in function within a single policy evaluation query
         // will always return the same value.
-        // This is by design and is documented in https://www.openpolicyagent.org/docs/latest/policy-reference/#time
+        // This is by design and is documented in https://www.openpolicyagent.org/docs/policy-reference/builtins/time
         let nanos = UInt64(ctx.timestamp.timeIntervalSince1970 * 1_000_000_000)
         return .number(RegoNumber(value: Int64(bitPattern: nanos)))
+    }
+
+    static func timeAddDate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 4 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 4)
+        }
+
+        guard case .number(let ns) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "ns", got: args[0].typeName, want: "number[integer]")
+        }
+
+        guard case .number(let years) = args[1] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "years", got: args[1].typeName, want: "number[integer]")
+        }
+
+        guard case .number(let months) = args[2] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "months", got: args[2].typeName, want: "number[integer]")
+        }
+
+        guard case .number(let days) = args[3] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "days", got: args[3].typeName, want: "number[integer]")
+        }
+
+        guard let nsInt64 = ns.int64Value else {
+            throw BuiltinError.evalError(msg: "operand 0 must be integer number but got floating-point number")
+        }
+
+        guard let yearsInt64 = years.int64Value else {
+            throw BuiltinError.evalError(msg: "operand 1 must be integer number but got floating-point number")
+        }
+
+        guard let monthsInt64 = months.int64Value else {
+            throw BuiltinError.evalError(msg: "operand 2 must be integer number but got floating-point number")
+        }
+
+        guard let daysInt64 = days.int64Value else {
+            throw BuiltinError.evalError(msg: "operand 3 must be integer number but got floating-point number")
+        }
+
+        // Use whole seconds only for Date to avoid floating-point precision loss on sub-second nanos.
+        let date = Date(timeIntervalSince1970: TimeInterval(nsInt64 / 1_000_000_000))
+        let components = DateComponents(
+            year: Int(clamping: yearsInt64), month: Int(clamping: monthsInt64), day: Int(clamping: daysInt64))
+
+        // Use UTC
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        guard let newDate = cal.date(byAdding: components, to: date) else {
+            throw BuiltinError.evalError(msg: "time.add_date: failed to compute resulting date")
+        }
+
+        // Reconstruct back to nanoseconds by preserving the sub-second part of the input.
+        let subSecondNanos = nsInt64 % 1_000_000_000
+        return .number(RegoNumber(int: try toSafeUnixNanos(newDate, subSecondNanos: subSecondNanos)))
+    }
+
+    /// Returns the nanoseconds since epoch as Int64,
+    /// or throws if the date falls outside the representable range
+    /// (1677-09-21T00:12:43Z to 2262-04-11T23:47:16Z).
+    /// See https://github.com/open-policy-agent/opa/blob/1ac64ef1a57a531c2723c59848890b88e816d777/v1/topdown/time.go#L30
+    private static func toSafeUnixNanos(_ date: Date, subSecondNanos: Int64 = 0) throws -> Int64 {
+        guard date >= minDateAllowedForNsConversion && date <= maxDateAllowedForNsConversion else {
+            throw BuiltinError.evalError(msg: "time outside of valid range")
+        }
+        /// Note that Go's time.Time stores nanoseconds internally and the min and max bounds are defined in terms of nanoseconds.
+        /// In our case, Date only has microsecond precision and so the overflow-reporting arithmetic approach is used to go from microseconds to nanos
+        let (wholeSecondsInNanos, overflow1) = Int64(date.timeIntervalSince1970).multipliedReportingOverflow(
+            by: 1_000_000_000)
+        let (result, overflow2) = wholeSecondsInNanos.addingReportingOverflow(subSecondNanos)
+        guard !overflow1 && !overflow2 else {
+            throw BuiltinError.evalError(msg: "time outside of valid range")
+        }
+        return result
     }
 }

--- a/Tests/RegoTests/BuiltinTests/TimeTests.swift
+++ b/Tests/RegoTests/BuiltinTests/TimeTests.swift
@@ -10,10 +10,97 @@ extension BuiltinTests {
 }
 
 extension BuiltinTests.TimeTests {
+    static let addDateTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "ns must be an integer",
+            name: "time.add_date",
+            args: [42.5, 0, 0, 0],
+            expected: .failure(
+                BuiltinError.evalError(msg: "operand 0 must be integer number but got floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "years must be an integer",
+            name: "time.add_date",
+            args: [12345, 0.75, 0, 0],
+            expected: .failure(
+                BuiltinError.evalError(msg: "operand 1 must be integer number but got floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "months must be an integer",
+            name: "time.add_date",
+            args: [12345, 0, 0.75, 0],
+            expected: .failure(
+                BuiltinError.evalError(msg: "operand 2 must be integer number but got floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "days must be an integer",
+            name: "time.add_date",
+            args: [12345, 0, 0, 0.75],
+            expected: .failure(
+                BuiltinError.evalError(msg: "operand 3 must be integer number but got floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "adds year month day",
+            name: "time.add_date",
+            args: [1_585_852_421_593_912_000, 3, 9, 12],
+            expected: .success(1_705_257_221_593_912_000)
+        ),
+        BuiltinTests.TestCase(
+            description: "adds negative values",
+            name: "time.add_date",
+            args: [1_585_852_421_593_912_000, -1, -1, -1],
+            expected: .success(1_551_465_221_593_912_000)
+        ),
+        BuiltinTests.TestCase(
+            description: "time outside of valid range: too large",
+            name: "time.add_date",
+            args: [0, 2262, 1, 1],
+            expected: .failure(
+                BuiltinError.evalError(msg: "time outside of valid range")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "time outside of valid range: too small",
+            name: "time.add_date",
+            args: [-9_223_372_036_854_775_808, 0, 0, -1],
+            expected: .failure(
+                BuiltinError.evalError(msg: "time outside of valid range"))
+        ),
+        // February has 28 days
+        // 2025-02-01 + 1 year = 2026-02-01, + 2 months = 2026-04-01, + 5 days = 2026-04-06
+        BuiltinTests.TestCase(
+            description: "adding 1 year 2 months 5 days to 2025-02-01",
+            name: "time.add_date",
+            args: [1_738_368_000_000_000_000, 1, 2, 5],
+            expected: .success(1_775_433_600_000_000_000)
+        ),
+    ]
+
     static var allTests: [BuiltinTests.TestCase] {
         [
+            BuiltinTests.generateFailureTests(
+                builtinName: "time.add_date", sampleArgs: [1_585_852_421_593_912_000, 3, 9, 12], argIndex: 0,
+                argName: "ns",
+                allowedArgTypes: ["number[integer]"],
+                generateNumberOfArgsTest: true, numberAsInteger: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "time.add_date", sampleArgs: [1_585_852_421_593_912_000, 3, 9, 12], argIndex: 1,
+                argName: "years",
+                allowedArgTypes: ["number[integer]"],
+                generateNumberOfArgsTest: false, numberAsInteger: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "time.add_date", sampleArgs: [1_585_852_421_593_912_000, 3, 9, 12], argIndex: 2,
+                argName: "months",
+                allowedArgTypes: ["number[integer]"],
+                generateNumberOfArgsTest: false, numberAsInteger: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "time.add_date", sampleArgs: [1_585_852_421_593_912_000, 3, 9, 12], argIndex: 3,
+                argName: "days",
+                allowedArgTypes: ["number[integer]"],
+                generateNumberOfArgsTest: false, numberAsInteger: true),
             BuiltinTests.generateNumberOfArgumentsFailureTests(
-                builtinName: "time.now_ns", sampleArgs: [])
+                builtinName: "time.now_ns", sampleArgs: []),
+            addDateTests,
         ].flatMap { $0 }
     }
 

--- a/capabilities.json
+++ b/capabilities.json
@@ -1548,6 +1548,29 @@
     },
     {
       "decl" : {
+        "args" : [
+          {
+            "type" : "number"
+          },
+          {
+            "type" : "number"
+          },
+          {
+            "type" : "number"
+          },
+          {
+            "type" : "number"
+          }
+        ],
+        "result" : {
+          "type" : "number"
+        },
+        "type" : "function"
+      },
+      "name" : "time.add_date"
+    },
+    {
+      "decl" : {
         "result" : {
           "type" : "number"
         },


### PR DESCRIPTION
### What code changed, and why?
This change implements [time.add_date](https://www.openpolicyagent.org/docs/policy-reference/builtins/time#builtin-time-timeadd_date) builtin and ensures existing compliance tests pass.

### Definition of done
All tests related to `time.add_date` now pass

### How to test
`make test`
`OPA_COMPLIANCE_TESTS="time" make test-compliance | grep add_date` 

### Related Resources
Related to #116

