### PR TITLE
builtins: add time.clock, time.date, and time.weekday

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINDIR ?= $(HOME)/bin
 OPA_BASE_CAPS_VERSION ?= v1.13.1
 
 .PHONY: all
-all: fmt lint test build
+all: fmt lint test generate build
 
 .PHONY: fmt
 fmt:

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -162,7 +162,10 @@ public struct BuiltinRegistry: Sendable {
 
             // Time
             "time.add_date": BuiltinFuncs.timeAddDate,
+            "time.clock": BuiltinFuncs.timeClock,
+            "time.date": BuiltinFuncs.timeDate,
             "time.now_ns": BuiltinFuncs.timeNowNanos,
+            "time.weekday": BuiltinFuncs.timeWeekday,
 
             // Trace
             "trace": BuiltinFuncs.trace,

--- a/Sources/Rego/Builtins/Time.swift
+++ b/Sources/Rego/Builtins/Time.swift
@@ -116,7 +116,11 @@ extension BuiltinFuncs {
     /// a UTC-based Gregorian `Calendar` configured with the specified timezone.
     private static func dateWithCalendar(_ arg: AST.RegoValue) throws -> (Date, Calendar) {
         let (ns, timeZone) = try parseNanosWithTimezone(arg)
-        let date = Date(timeIntervalSince1970: TimeInterval(ns / 1_000_000_000))
+        // Use floor division rather than truncation.
+        // Without this, negative timestamps with sub-second nanos land in the wrong second,
+        // e.g. ns=-900_000_000 (-0.9s) would truncate to 0 (epoch) instead of -1 (1969-12-31 23:59:59).
+        let wholeSeconds = ns / 1_000_000_000 - (ns % 1_000_000_000 < 0 ? 1 : 0)
+        let date = Date(timeIntervalSince1970: TimeInterval(wholeSeconds))
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = timeZone
         return (date, cal)

--- a/Sources/Rego/Builtins/Time.swift
+++ b/Sources/Rego/Builtins/Time.swift
@@ -3,8 +3,10 @@ import Foundation
 
 private let minDateAllowedForNsConversion = Date(timeIntervalSince1970: TimeInterval(Int64.min) / 1_000_000_000)
 private let maxDateAllowedForNsConversion = Date(timeIntervalSince1970: TimeInterval(Int64.max) / 1_000_000_000)
+private let weekdayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
 extension BuiltinFuncs {
+    // MARK: - time.now_ns
     static func timeNowNanos(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 0 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 0)
@@ -17,6 +19,7 @@ extension BuiltinFuncs {
         return .number(RegoNumber(value: Int64(bitPattern: nanos)))
     }
 
+    // MARK: - time.add_date
     static func timeAddDate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
         guard args.count == 4 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 4)
@@ -69,6 +72,96 @@ extension BuiltinFuncs {
         // Reconstruct back to nanoseconds by preserving the sub-second part of the input.
         let subSecondNanos = nsInt64 % 1_000_000_000
         return .number(RegoNumber(int: try toSafeUnixNanos(newDate, subSecondNanos: subSecondNanos)))
+    }
+
+    // MARK: - time.clock
+    static func timeClock(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        let (date, cal) = try dateWithCalendar(args[0])
+        let comps = cal.dateComponents([.hour, .minute, .second], from: date)
+        return .array([
+            .number(RegoNumber(int: Int64(comps.hour ?? 0))),
+            .number(RegoNumber(int: Int64(comps.minute ?? 0))),
+            .number(RegoNumber(int: Int64(comps.second ?? 0))),
+        ])
+    }
+
+    // MARK: - time.date
+    static func timeDate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        let (date, cal) = try dateWithCalendar(args[0])
+        let comps = cal.dateComponents([.year, .month, .day], from: date)
+        return .array([
+            .number(RegoNumber(int: Int64(comps.year ?? 0))),
+            .number(RegoNumber(int: Int64(comps.month ?? 0))),
+            .number(RegoNumber(int: Int64(comps.day ?? 0))),
+        ])
+    }
+
+    // MARK: - time.weekday
+    static func timeWeekday(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        let (date, cal) = try dateWithCalendar(args[0])
+        return .string(weekdayNames[cal.component(.weekday, from: date) - 1])
+    }
+
+    // MARK: - private utilities
+    /// Parses `nanoseconds` or `[nanoseconds, timezone]` argument and returns the corresponding `Date` and
+    /// a UTC-based Gregorian `Calendar` configured with the specified timezone.
+    private static func dateWithCalendar(_ arg: AST.RegoValue) throws -> (Date, Calendar) {
+        let (ns, timeZone) = try parseNanosWithTimezone(arg)
+        let date = Date(timeIntervalSince1970: TimeInterval(ns / 1_000_000_000))
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = timeZone
+        return (date, cal)
+    }
+
+    /// Parses a time.clock/time.date argument which is either ns (number) or [ns, timezone] (array).
+    /// Mirrors golang's OPA: throws "timestamp too big" if ns does not fit in Int64.
+    private static func parseNanosWithTimezone(_ arg: AST.RegoValue) throws -> (Int64, TimeZone) {
+        let floatNsError = "timestamp must be an integer, but got a floating-point number"
+        switch arg {
+        case .number(let x):
+            guard let ns = x.int64Value else {
+                if x.clampedUint64Value > Int64.max {
+                    throw BuiltinError.evalError(msg: "timestamp too big")
+                }
+                throw BuiltinError.evalError(msg: floatNsError)
+            }
+            return (ns, TimeZone(identifier: "UTC")!)
+        case .array(let a) where a.count == 2:
+            guard case .number(let x) = a[0] else {
+                throw BuiltinError.argumentTypeMismatch(arg: "nanoseconds", got: arg.typeName, want: "number[integer]")
+            }
+            guard let ns = x.int64Value else {
+                if x.clampedUint64Value > Int64.max {
+                    throw BuiltinError.evalError(msg: "timestamp too big")
+                }
+                throw BuiltinError.evalError(msg: floatNsError)
+            }
+            guard case .string(let timeZoneName) = a[1] else {
+                throw BuiltinError.argumentTypeMismatch(arg: "timeZone", got: arg.typeName, want: "string")
+            }
+            guard !timeZoneName.isEmpty else {
+                return (ns, TimeZone(identifier: "UTC")!)
+            }
+            if timeZoneName.lowercased() == "local" {
+                return (ns, TimeZone.current)
+            }
+            guard let tz = TimeZone(identifier: String(timeZoneName)) else {
+                throw BuiltinError.evalError(msg: "unknown timezone: \(timeZoneName)")
+            }
+            return (ns, tz)
+        default:
+            throw BuiltinError.argumentTypeMismatch(
+                arg: "x", got: arg.typeName, want: "any<number[integer], array<number[integer], string>>")
+        }
     }
 
     /// Returns the nanoseconds since epoch as Int64,

--- a/Tests/RegoTests/BuiltinTests/TimeTests.swift
+++ b/Tests/RegoTests/BuiltinTests/TimeTests.swift
@@ -164,6 +164,20 @@ extension BuiltinTests.TimeTests {
             args: [1_582_977_600_000_000_000],
             expected: .success([12, 0, 0])
         ),
+        // Sub-second into new year: 2020-01-01 00:00:00.9 UTC — clock must be 00:00:00
+        BuiltinTests.TestCase(
+            description: "1ns truncation does not affect clock",
+            name: "time.clock",
+            args: [1_577_836_800_000_000_001],
+            expected: .success([0, 0, 0])
+        ),
+        // Negative ns: -900_000_000 = 1969-12-31 23:59:59.1 UTC
+        BuiltinTests.TestCase(
+            description: "negative sub-second ns returns correct clock (pre-epoch)",
+            name: "time.clock",
+            args: [-900_000_000],
+            expected: .success([23, 59, 59])
+        ),
         BuiltinTests.TestCase(
             description: "unknown timezone",
             name: "time.clock",
@@ -259,6 +273,20 @@ extension BuiltinTests.TimeTests {
             name: "time.date",
             args: [1_582_977_600_000_000_000],
             expected: .success([2020, 2, 29])
+        ),
+        // Sub-second into new year: 2020-01-01 00:00:00.9 UTC — date must be Jan 1
+        BuiltinTests.TestCase(
+            description: "1ns truncation does not affect date",
+            name: "time.date",
+            args: [1_577_836_800_000_000_001],
+            expected: .success([2020, 1, 1])
+        ),
+        // Negative ns: -900_000_000 = 1969-12-31 23:59:59.1 UTC
+        BuiltinTests.TestCase(
+            description: "negative sub-second ns returns correct date (pre-epoch)",
+            name: "time.date",
+            args: [-900_000_000],
+            expected: .success([1969, 12, 31])
         ),
         BuiltinTests.TestCase(
             description: "unknown timezone",
@@ -381,6 +409,20 @@ extension BuiltinTests.TimeTests {
             expected: .failure(
                 BuiltinError.evalError(msg: "unknown timezone: foo/bar"))
         ),
+        // Negative ns: -900_000_000 = 1969-12-31 23:59:59.1 UTC (Wednesday)
+        BuiltinTests.TestCase(
+            description: "negative sub-second ns returns correct weekday (pre-epoch)",
+            name: "time.weekday",
+            args: [-900_000_000],
+            expected: .success("Wednesday")
+        ),
+        // Sub-second into new year: 2020-01-01 00:00:00.000000001 UTC — weekday must be Wednesday
+        BuiltinTests.TestCase(
+            description: "1ns truncation does not affect weekday",
+            name: "time.weekday",
+            args: [1_577_836_800_000_000_001],
+            expected: .success("Wednesday")
+        ),
     ]
 
     // MARK: - All time Tests
@@ -414,6 +456,12 @@ extension BuiltinTests.TimeTests {
                 generateNumberOfArgsTest: true, numberAsInteger: true),
             BuiltinTests.generateFailureTests(
                 builtinName: "time.date", sampleArgs: [[1_585_852_421_593_912_000, "UTC"]], argIndex: 0,
+                argName: "x",
+                allowedArgTypes: ["array", "number[integer]"],
+                wantArgs: "any<number[integer], array<number[integer], string>>",
+                generateNumberOfArgsTest: true, numberAsInteger: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "time.weekday", sampleArgs: [[1_585_852_421_593_912_000, "UTC"]], argIndex: 0,
                 argName: "x",
                 allowedArgTypes: ["array", "number[integer]"],
                 wantArgs: "any<number[integer], array<number[integer], string>>",

--- a/Tests/RegoTests/BuiltinTests/TimeTests.swift
+++ b/Tests/RegoTests/BuiltinTests/TimeTests.swift
@@ -10,6 +10,7 @@ extension BuiltinTests {
 }
 
 extension BuiltinTests.TimeTests {
+    // MARK: - time.add_date Tests
     static let addDateTests: [BuiltinTests.TestCase] = [
         BuiltinTests.TestCase(
             description: "ns must be an integer",
@@ -76,6 +77,313 @@ extension BuiltinTests.TimeTests {
         ),
     ]
 
+    // MARK: - time.clock Tests
+    static let clockTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "x must be an integer",
+            name: "time.clock",
+            args: [42.5],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp must be an integer, but got a floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "timestamp too big",
+            name: "time.clock",
+            args: [.number(RegoNumber(nsNumber: UInt64.max as NSNumber))],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp too big"))
+        ),
+        BuiltinTests.TestCase(
+            description: "x[0] must be an integer when array is used",
+            name: "time.clock",
+            args: [[42.5, "UTC"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp must be an integer, but got a floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "x[0] timestamp too big when array is used",
+            name: "time.clock",
+            args: [[.number(RegoNumber(nsNumber: UInt64.max as NSNumber)), "UTC"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp too big"))
+        ),
+        BuiltinTests.TestCase(
+            description: "empty array",
+            name: "time.clock",
+            args: [[]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "single element array",
+            name: "time.clock",
+            args: [[123]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "long array",
+            name: "time.clock",
+            args: [[123, "UTC", 0]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "12:01:02 (defaults to UTC tz)",
+            name: "time.clock",
+            args: [1_517_832_062_000_000_000],
+            expected: .success([12, 1, 2])
+        ),
+        BuiltinTests.TestCase(
+            description: "12:01:02 in UTC tz",
+            name: "time.clock",
+            args: [[1_517_832_062_000_000_000, "UTC"]],
+            expected: .success([12, 1, 2])
+        ),
+        BuiltinTests.TestCase(
+            description: "7:01:02 in NYC tz",
+            name: "time.clock",
+            args: [[1_517_832_062_000_000_000, "America/New_York"]],
+            expected: .success([7, 1, 2])
+        ),
+        BuiltinTests.TestCase(
+            description: "12:00:00 in a leap day",
+            name: "time.clock",
+            args: [1_582_977_600_000_000_000],
+            expected: .success([12, 0, 0])
+        ),
+        BuiltinTests.TestCase(
+            description: "unknown timezone",
+            name: "time.clock",
+            args: [[1_517_814_000_000_000_000, "foo/bar"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "unknown timezone: foo/bar"))
+        ),
+    ]
+
+    // MARK: - time.date Tests
+    static let dateTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "x must be an integer",
+            name: "time.date",
+            args: [42.5],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp must be an integer, but got a floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "timestamp too big",
+            name: "time.date",
+            args: [.number(RegoNumber(nsNumber: UInt64.max as NSNumber))],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp too big"))
+        ),
+        BuiltinTests.TestCase(
+            description: "x[0] must be an integer when array is used",
+            name: "time.date",
+            args: [[42.5, "UTC"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp must be an integer, but got a floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "x[0] timestamp too big when array is used",
+            name: "time.date",
+            args: [[.number(RegoNumber(nsNumber: UInt64.max as NSNumber)), "UTC"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp too big"))
+        ),
+        BuiltinTests.TestCase(
+            description: "empty array",
+            name: "time.date",
+            args: [[]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "single element array",
+            name: "time.date",
+            args: [[123]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "long array",
+            name: "time.date",
+            args: [[123, "UTC", 0]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "2018-02-05 (defaults to UTC tz)",
+            name: "time.date",
+            args: [1_517_814_000_000_000_000],
+            expected: .success([2018, 2, 5])
+        ),
+        BuiltinTests.TestCase(
+            description: "2018-02-05 in UTC tz",
+            name: "time.date",
+            args: [[1_517_814_000_000_000_000, "UTC"]],
+            expected: .success([2018, 2, 5])
+        ),
+        BuiltinTests.TestCase(
+            description: "2018-02-04 in LA tz",
+            name: "time.date",
+            args: [[1_517_814_000_000_000_000, "America/Los_Angeles"]],
+            expected: .success([2018, 2, 4])
+        ),
+        BuiltinTests.TestCase(
+            description: "2020-02-29 is a leap day",
+            name: "time.date",
+            args: [1_582_977_600_000_000_000],
+            expected: .success([2020, 2, 29])
+        ),
+        BuiltinTests.TestCase(
+            description: "unknown timezone",
+            name: "time.date",
+            args: [[1_517_814_000_000_000_000, "foo/bar"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "unknown timezone: foo/bar"))
+        ),
+    ]
+
+    // MARK: - time.weekday Tests
+    static let weekdayTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "x must be an integer",
+            name: "time.weekday",
+            args: [42.5],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp must be an integer, but got a floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "timestamp too big",
+            name: "time.weekday",
+            args: [[.number(RegoNumber(nsNumber: UInt64.max as NSNumber)), "UTC"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp too big"))
+        ),
+        BuiltinTests.TestCase(
+            description: "x[0] must be an integer when array is used",
+            name: "time.weekday",
+            args: [[42.5, "UTC"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp must be an integer, but got a floating-point number"))
+        ),
+        BuiltinTests.TestCase(
+            description: "x[0] timestamp too big when array is used",
+            name: "time.weekday",
+            args: [[.number(RegoNumber(nsNumber: UInt64.max as NSNumber)), "UTC"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "timestamp too big"))
+        ),
+        BuiltinTests.TestCase(
+            description: "empty array",
+            name: "time.weekday",
+            args: [[]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "single element array",
+            name: "time.weekday",
+            args: [[123]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "long array",
+            name: "time.weekday",
+            args: [[123, "UTC", 0]],
+            expected: .failure(
+                BuiltinError.argumentTypeMismatch(
+                    arg: "x",
+                    got: "array",
+                    want: "any<number[integer], array<number[integer], string>>")
+            )
+        ),
+        BuiltinTests.TestCase(
+            description: "Monday",
+            name: "time.weekday",
+            args: [1_517_832_000_000_000_000],
+            expected: .success("Monday")
+        ),
+        BuiltinTests.TestCase(
+            description: "Tuesday",
+            name: "time.weekday",
+            args: [1_517_918_400_000_000_000],
+            expected: .success("Tuesday")
+        ),
+        BuiltinTests.TestCase(
+            description: "Wednesday",
+            name: "time.weekday",
+            args: [1_518_004_800_000_000_000],
+            expected: .success("Wednesday")
+        ),
+        BuiltinTests.TestCase(
+            description: "Thursday",
+            name: "time.weekday",
+            args: [1_518_091_200_000_000_000],
+            expected: .success("Thursday")
+        ),
+        BuiltinTests.TestCase(
+            description: "Friday",
+            name: "time.weekday",
+            args: [1_518_177_600_000_000_000],
+            expected: .success("Friday")
+        ),
+        BuiltinTests.TestCase(
+            description: "Saturday",
+            name: "time.weekday",
+            args: [1_518_264_000_000_000_000],
+            expected: .success("Saturday")
+        ),
+        BuiltinTests.TestCase(
+            description: "Sunday",
+            name: "time.weekday",
+            args: [1_518_350_400_000_000_000],
+            expected: .success("Sunday")
+        ),
+        BuiltinTests.TestCase(
+            description: "unknown timezone",
+            name: "time.weekday",
+            args: [[1_517_814_000_000_000_000, "foo/bar"]],
+            expected: .failure(
+                BuiltinError.evalError(msg: "unknown timezone: foo/bar"))
+        ),
+    ]
+
+    // MARK: - All time Tests
     static var allTests: [BuiltinTests.TestCase] {
         [
             BuiltinTests.generateFailureTests(
@@ -98,9 +406,24 @@ extension BuiltinTests.TimeTests {
                 argName: "days",
                 allowedArgTypes: ["number[integer]"],
                 generateNumberOfArgsTest: false, numberAsInteger: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "time.clock", sampleArgs: [[1_585_852_421_593_912_000, "UTC"]], argIndex: 0,
+                argName: "x",
+                allowedArgTypes: ["array", "number[integer]"],
+                wantArgs: "any<number[integer], array<number[integer], string>>",
+                generateNumberOfArgsTest: true, numberAsInteger: true),
+            BuiltinTests.generateFailureTests(
+                builtinName: "time.date", sampleArgs: [[1_585_852_421_593_912_000, "UTC"]], argIndex: 0,
+                argName: "x",
+                allowedArgTypes: ["array", "number[integer]"],
+                wantArgs: "any<number[integer], array<number[integer], string>>",
+                generateNumberOfArgsTest: true, numberAsInteger: true),
             BuiltinTests.generateNumberOfArgumentsFailureTests(
                 builtinName: "time.now_ns", sampleArgs: []),
             addDateTests,
+            clockTests,
+            dateTests,
+            weekdayTests,
         ].flatMap { $0 }
     }
 
@@ -109,6 +432,7 @@ extension BuiltinTests.TimeTests {
         try await BuiltinTests.testBuiltin(tc: tc)
     }
 
+    // MARK: - time.now_ns Tests
     @Test
     func timeNowNanosReturnsValidTime() async throws {
         let expected = UInt64(Date().timeIntervalSince1970 * 1_000_000_000)

--- a/capabilities.json
+++ b/capabilities.json
@@ -1613,6 +1613,88 @@
     },
     {
       "decl" : {
+        "args" : [
+          {
+            "of" : [
+              {
+                "type" : "number"
+              },
+              {
+                "static" : [
+                  {
+                    "type" : "number"
+                  },
+                  {
+                    "type" : "string"
+                  }
+                ],
+                "type" : "array"
+              }
+            ],
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "static" : [
+            {
+              "type" : "number"
+            },
+            {
+              "type" : "number"
+            },
+            {
+              "type" : "number"
+            }
+          ],
+          "type" : "array"
+        },
+        "type" : "function"
+      },
+      "name" : "time.clock"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "of" : [
+              {
+                "type" : "number"
+              },
+              {
+                "static" : [
+                  {
+                    "type" : "number"
+                  },
+                  {
+                    "type" : "string"
+                  }
+                ],
+                "type" : "array"
+              }
+            ],
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "static" : [
+            {
+              "type" : "number"
+            },
+            {
+              "type" : "number"
+            },
+            {
+              "type" : "number"
+            }
+          ],
+          "type" : "array"
+        },
+        "type" : "function"
+      },
+      "name" : "time.date"
+    },
+    {
+      "decl" : {
         "result" : {
           "type" : "number"
         },
@@ -1620,6 +1702,36 @@
       },
       "name" : "time.now_ns",
       "nondeterministic" : true
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "of" : [
+              {
+                "type" : "number"
+              },
+              {
+                "static" : [
+                  {
+                    "type" : "number"
+                  },
+                  {
+                    "type" : "string"
+                  }
+                ],
+                "type" : "array"
+              }
+            ],
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "type" : "string"
+        },
+        "type" : "function"
+      },
+      "name" : "time.weekday"
     },
     {
       "decl" : {


### PR DESCRIPTION
### What code changed, and why?
The following builtins have been implemented:
* [time.clock](https://www.openpolicyagent.org/docs/policy-reference/builtins/time#builtin-time-timeclock)
* [time.date](https://www.openpolicyagent.org/docs/policy-reference/builtins/time#builtin-time-timedate)
* [time.weekday](https://www.openpolicyagent.org/docs/policy-reference/builtins/time#builtin-time-timeweekday)

### Definition of done
Compliance tests pass:
```
✅ time/test-time-0951.json: time/date -> eval
✅ time/test-time-0952.json: time/date with LA tz -> eval
✅ time/test-time-0953.json: time/date with empty tz -> eval
✅ time/test-time-0954.json: time/date leap day -> eval
✅ time/test-time-0955.json: time/date too big -> eval
✅ time/test-time-0956.json: time/clock -> eval
✅ time/test-time-0957.json: time/clock with NY tz -> eval
✅ time/test-time-0958.json: time/clock leap day -> eval
✅ time/test-time-0959.json: time/clock too big -> eval
✅ time/test-time-0960.json: time/weekday -> eval
✅ time/test-time-0961.json: time/weekday -> eval
✅ time/test-time-0962.json: time/weekday -> eval
✅ time/test-time-0963.json: time/weekday -> eval
✅ time/test-time-0964.json: time/weekday -> eval
✅ time/test-time-0965.json: time/weekday -> eval
✅ time/test-time-0966.json: time/weekday -> eval
✅ time/test-time-0967.json: time/weekday too big -> eval
```

### How to test
```
make all
OPA_COMPLIANCE_TESTS="time" make test-compliance | grep -E "weekday|clock|date"
```

### Related Resources
Related to #116

