### PR TITLE
ci: Fix wrong path for release notes script.

### DIFF
--- a/tools/build/github-release.sh
+++ b/tools/build/github-release.sh
@@ -30,7 +30,7 @@ RELEASE_NOTES="release-notes.md"
 echo -e "${TAG_NAME}\n" > "${RELEASE_NOTES}"
 
 # Fill in the description
-./build/latest-release-notes.sh --output="${RELEASE_NOTES}"
+./tools/build/latest-release-notes.sh --output="${RELEASE_NOTES}"
 
 # Update or create a release on github
 if gh release view "${TAG_NAME}" --repo open-policy-agent/swift-opa > /dev/null; then


### PR DESCRIPTION
### What code changed, and why?

This commit fixes an incorrect path in our github release automation script that resulted in no release notes being generated for the `0.0.2` release. (I had to manually copy the CHANGELOG contents over. 🙃)

The problem was that `tools/build/github-release.sh` was looking in the wrong place for the `latest-release-notes.sh` script.

### How to test

 - On next release, observe whether or not the Github Draft Release has contents from our `CHANGELOG.md` file or not.

### Related Resources

