### PR TITLE
builtins: implement semver

### DIFF
--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -130,6 +130,10 @@ public struct BuiltinRegistry: Sendable {
             // Rand
             "rand.intn": BuiltinFuncs.numbersRandIntN,
 
+            // SemVer
+            "semver.compare": BuiltinFuncs.semverCompare,
+            "semver.is_valid": BuiltinFuncs.semverIsValid,
+
             // Sets
             "and": BuiltinFuncs.and,
             "intersection": BuiltinFuncs.intersection,

--- a/Sources/Rego/Builtins/Semver.swift
+++ b/Sources/Rego/Builtins/Semver.swift
@@ -1,0 +1,144 @@
+import AST
+import Foundation
+
+extension BuiltinFuncs {
+    // MARK: - semver.is_valid
+    static func semverIsValid(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        guard case .string(let vsn) = args[0] else {
+            return .boolean(false)
+        }
+        return .boolean(SemVer.parse(String(vsn)) != nil)
+    }
+
+    // MARK: - semver.compare
+    static func semverCompare(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+        guard args.count == 2 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
+        }
+        guard case .string(let a) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "a", got: args[0].typeName, want: "string")
+        }
+        guard case .string(let b) = args[1] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "b", got: args[1].typeName, want: "string")
+        }
+        guard let vA = SemVer.parse(String(a)) else {
+            throw BuiltinError.evalError(msg: "operand 1: string \(a) is not a valid SemVer")
+        }
+        guard let vB = SemVer.parse(String(b)) else {
+            throw BuiltinError.evalError(msg: "operand 2: string \(b) is not a valid SemVer")
+        }
+        return .number(RegoNumber(int: Int64(vA.compare(vB))))
+    }
+}
+
+// MARK: - SemVer parser and comparator
+
+/// Parsed representation of a semantic version (https://semver.org).
+/// Mirrors Golang OPA internal/semver package behaviour.
+private struct SemVer {
+    let major: Int64
+    let minor: Int64
+    let patch: Int64
+    let preRelease: String
+    // Metadata is ignored for comparison per the semver spec.
+
+    /// Parses a semver string, accepting an optional leading `v`.
+    /// Returns nil if the string is not a valid semver.
+    static func parse(_ input: String) -> SemVer? {
+        var s = input
+        if s.hasPrefix("v") {
+            s = String(s.dropFirst())
+        }
+
+        // Split off build metadata (+)
+        let metadata: String
+        if let plusIdx = s.firstIndex(of: "+") {
+            metadata = String(s[s.index(after: plusIdx)...])
+            s = String(s[..<plusIdx])
+            guard isValidIdentifier(metadata) else { return nil }
+        } else {
+            metadata = ""
+        }
+
+        // Split off pre-release (-)
+        let preRelease: String
+        if let dashIdx = s.firstIndex(of: "-") {
+            preRelease = String(s[s.index(after: dashIdx)...])
+            s = String(s[..<dashIdx])
+            guard isValidIdentifier(preRelease) else { return nil }
+        } else {
+            preRelease = ""
+        }
+
+        // Core version must be exactly major.minor.patch
+        let parts = s.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+            let major = Int64(parts[0]),
+            let minor = Int64(parts[1]),
+            let patch = Int64(parts[2])
+        else { return nil }
+
+        return SemVer(major: major, minor: minor, patch: patch, preRelease: preRelease)
+    }
+
+    /// Compares self to other, returning -1, 0, or 1.
+    func compare(_ other: SemVer) -> Int {
+        for (a, b) in [(major, other.major), (minor, other.minor), (patch, other.patch)] {
+            if a != b { return a < b ? -1 : 1 }
+        }
+
+        // Equal core version: no pre-release > has pre-release
+        if preRelease == other.preRelease { return 0 }
+        if preRelease.isEmpty { return 1 }
+        if other.preRelease.isEmpty { return -1 }
+
+        // Compare pre-release identifiers dot by dot
+        var aPreReleaseParts = preRelease.split(separator: ".", omittingEmptySubsequences: false).map(String.init)[...]
+        var bPreReleaseParts = other.preRelease.split(separator: ".", omittingEmptySubsequences: false).map(
+            String.init)[...]
+
+        while !aPreReleaseParts.isEmpty || !bPreReleaseParts.isEmpty {
+            let a = aPreReleaseParts.first ?? ""
+            let b = bPreReleaseParts.first ?? ""
+            // Advance
+            if !aPreReleaseParts.isEmpty { aPreReleaseParts = aPreReleaseParts.dropFirst() }
+            if !bPreReleaseParts.isEmpty { bPreReleaseParts = bPreReleaseParts.dropFirst() }
+
+            if a.isEmpty { return -1 }
+            if b.isEmpty { return 1 }
+
+            let aIsInt = SemVer.isAllDigits(a)
+            let bIsInt = SemVer.isAllDigits(b)
+
+            if aIsInt && !bIsInt { return -1 }
+            if !aIsInt && bIsInt { return 1 }
+
+            if aIsInt, let aInt = Int64(a), let bInt = Int64(b) {
+                if aInt != bInt { return aInt < bInt ? -1 : 1 }
+            } else {
+                if a != b { return a < b ? -1 : 1 }
+            }
+        }
+        return 0
+    }
+
+    // MARK: - Helpers
+
+    private static func isValidIdentifier(_ s: String) -> Bool {
+        guard !s.isEmpty else { return false }
+        return s.split(separator: ".", omittingEmptySubsequences: false).allSatisfy { component in
+            !component.isEmpty && component.allSatisfy(isAlphanumericOrHyphen)
+        }
+    }
+
+    private static func isAlphanumericOrHyphen(_ c: Character) -> Bool {
+        (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || (c >= "0" && c <= "9") || c == "-"
+    }
+
+    private static func isAllDigits(_ s: String) -> Bool {
+        !s.isEmpty && s.allSatisfy(\.isNumber)
+    }
+}

--- a/Tests/RegoTests/BuiltinTests/SemverTests.swift
+++ b/Tests/RegoTests/BuiltinTests/SemverTests.swift
@@ -72,6 +72,12 @@ extension BuiltinTests.SemverTests {
         "1.2.3.4",
         "0.88.0-11_e4e5dcabb",
         "0.88.0+11_e4e5dcabb",
+        "1..2.3",
+        "1.2.3..",
+        "1.2..3",
+        "...1.2.3",
+        "foo",
+        "x.y.z",
     ]
 
     // MARK: - semver.compare test cases
@@ -80,28 +86,28 @@ extension BuiltinTests.SemverTests {
         for (greater, lesser) in greaterLesserFixtures {
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "compare: \(greater) > \(lesser)",
+                    description: "\(greater) > \(lesser)",
                     name: "semver.compare",
                     args: [.string(greater), .string(lesser)],
                     expected: .success(1)
                 ))
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "compare: \(lesser) < \(greater)",
+                    description: "\(lesser) < \(greater)",
                     name: "semver.compare",
                     args: [.string(lesser), .string(greater)],
                     expected: .success(-1)
                 ))
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "compare: v\(lesser) < \(greater)",
+                    description: "v\(lesser) < \(greater)",
                     name: "semver.compare",
                     args: [.string("v" + lesser), .string(greater)],
                     expected: .success(-1)
                 ))
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "compare: \(lesser) < v\(greater)",
+                    description: "\(lesser) < v\(greater)",
                     name: "semver.compare",
                     args: [.string(lesser), .string("v" + greater)],
                     expected: .success(-1)
@@ -110,14 +116,14 @@ extension BuiltinTests.SemverTests {
         for v in equalFixtures {
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "compare: \(v) == \(v)",
+                    description: "\(v) == \(v)",
                     name: "semver.compare",
                     args: [.string(v), .string(v)],
                     expected: .success(0)
                 ))
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "compare: \(v) == v\(v)",
+                    description: "\(v) == v\(v)",
                     name: "semver.compare",
                     args: [.string(v), .string("v" + v)],
                     expected: .success(0)
@@ -149,14 +155,14 @@ extension BuiltinTests.SemverTests {
         for v in equalFixtures {
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "is_valid: \(v) is valid",
+                    description: "\(v) is valid",
                     name: "semver.is_valid",
                     args: [.string(v)],
                     expected: .success(true)
                 ))
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "is_valid: v\(v) is valid",
+                    description: "v\(v) is valid",
                     name: "semver.is_valid",
                     args: [.string("v" + v)],
                     expected: .success(true)
@@ -165,7 +171,7 @@ extension BuiltinTests.SemverTests {
         for v in badInputFixtures {
             cases.append(
                 BuiltinTests.TestCase(
-                    description: "is_valid: \(v) is invalid",
+                    description: "\(v) is NOT valid",
                     name: "semver.is_valid",
                     args: [.string(v)],
                     expected: .success(false)

--- a/Tests/RegoTests/BuiltinTests/SemverTests.swift
+++ b/Tests/RegoTests/BuiltinTests/SemverTests.swift
@@ -1,0 +1,213 @@
+import AST
+import Foundation
+import Testing
+
+@testable import Rego
+
+extension BuiltinTests {
+    @Suite("BuiltinTests - SemVer", .tags(.builtins))
+    struct SemverTests {}
+}
+
+extension BuiltinTests.SemverTests {
+    // Pairs where the first element is greater than the second.
+    static let greaterLesserFixtures: [(String, String)] = [
+        ("0.0.0", "0.0.0-foo"),
+        ("0.0.1", "0.0.0"),
+        ("1.0.0", "0.9.9"),
+        ("0.10.0", "0.9.0"),
+        ("0.99.0", "0.10.0"),
+        ("2.0.0", "1.2.3"),
+        ("0.0.0", "0.0.0-foo"),
+        ("0.0.1", "0.0.0"),
+        ("1.0.0", "0.9.9"),
+        ("0.10.0", "0.9.0"),
+        ("0.99.0", "0.10.0"),
+        ("2.0.0", "1.2.3"),
+        ("0.0.0", "0.0.0-foo"),
+        ("0.0.1", "0.0.0"),
+        ("1.0.0", "0.9.9"),
+        ("0.10.0", "0.9.0"),
+        ("0.99.0", "0.10.0"),
+        ("2.0.0", "1.2.3"),
+        ("1.2.3", "1.2.3-asdf"),
+        ("1.2.3", "1.2.3-4"),
+        ("1.2.3", "1.2.3-4-foo"),
+        ("1.2.3-5-foo", "1.2.3-5"),
+        ("1.2.3-5", "1.2.3-4"),
+        ("1.2.3-5-foo", "1.2.3-5-Foo"),
+        ("3.0.0", "2.7.2+asdf"),
+        ("3.0.0+foobar", "2.7.2"),
+        ("1.2.3-a.10", "1.2.3-a.5"),
+        ("1.2.3-a.b", "1.2.3-a.5"),
+        ("1.2.3-a.b", "1.2.3-a"),
+        ("1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100"),
+        ("1.0.0", "1.0.0-rc.1"),
+        ("1.0.0-rc.2", "1.0.0-rc.1"),
+        ("1.0.0-rc.1", "1.0.0-beta.11"),
+        ("1.0.0-beta.11", "1.0.0-beta.2"),
+        ("1.0.0-beta.2", "1.0.0-beta"),
+        ("1.0.0-beta", "1.0.0-alpha.beta"),
+        ("1.0.0-alpha.beta", "1.0.0-alpha.1"),
+        ("1.0.0-alpha.1", "1.0.0-alpha"),
+        ("1.2.3-rc.1-1-1hash", "1.2.3-rc.2"),
+    ]
+
+    // Versions that compare equal to themselves.
+    static let equalFixtures: [String] = [
+        "0.0.0",
+        "1.2.3",
+        "1.2.3-rc.1",
+        "1.2.3+build.123",
+        "1.2.3-rc.1+build.123",
+        "1.2.3-rc.1+build.123.444",
+    ]
+
+    // Invalid semver strings.
+    static let badInputFixtures: [String] = [
+        "1.2",
+        "1.2.3x",
+        "0x1.3.4",
+        "-1.2.3",
+        "1.2.3.4",
+        "0.88.0-11_e4e5dcabb",
+        "0.88.0+11_e4e5dcabb",
+    ]
+
+    // MARK: - semver.compare test cases
+    static var compareTests: [BuiltinTests.TestCase] {
+        var cases: [BuiltinTests.TestCase] = []
+        for (greater, lesser) in greaterLesserFixtures {
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "compare: \(greater) > \(lesser)",
+                    name: "semver.compare",
+                    args: [.string(greater), .string(lesser)],
+                    expected: .success(1)
+                ))
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "compare: \(lesser) < \(greater)",
+                    name: "semver.compare",
+                    args: [.string(lesser), .string(greater)],
+                    expected: .success(-1)
+                ))
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "compare: v\(lesser) < \(greater)",
+                    name: "semver.compare",
+                    args: [.string("v" + lesser), .string(greater)],
+                    expected: .success(-1)
+                ))
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "compare: \(lesser) < v\(greater)",
+                    name: "semver.compare",
+                    args: [.string(lesser), .string("v" + greater)],
+                    expected: .success(-1)
+                ))
+        }
+        for v in equalFixtures {
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "compare: \(v) == \(v)",
+                    name: "semver.compare",
+                    args: [.string(v), .string(v)],
+                    expected: .success(0)
+                ))
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "compare: \(v) == v\(v)",
+                    name: "semver.compare",
+                    args: [.string(v), .string("v" + v)],
+                    expected: .success(0)
+                ))
+        }
+        return cases
+    }
+
+    static let otherCompareTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "compare: a must be valid semver",
+            name: "semver.compare",
+            args: ["not-a-semver", "1.0.0"],
+            expected: .failure(
+                BuiltinError.evalError(msg: "operand 1: string not-a-semver is not a valid SemVer"))
+        ),
+        BuiltinTests.TestCase(
+            description: "compare: b must be valid semver",
+            name: "semver.compare",
+            args: ["1.0.0", "not-a-semver"],
+            expected: .failure(
+                BuiltinError.evalError(msg: "operand 2: string not-a-semver is not a valid SemVer"))
+        ),
+    ]
+
+    // MARK: - semver.is_valid test cases
+    static var isValidTests: [BuiltinTests.TestCase] {
+        var cases: [BuiltinTests.TestCase] = []
+        for v in equalFixtures {
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "is_valid: \(v) is valid",
+                    name: "semver.is_valid",
+                    args: [.string(v)],
+                    expected: .success(true)
+                ))
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "is_valid: v\(v) is valid",
+                    name: "semver.is_valid",
+                    args: [.string("v" + v)],
+                    expected: .success(true)
+                ))
+        }
+        for v in badInputFixtures {
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "is_valid: \(v) is invalid",
+                    name: "semver.is_valid",
+                    args: [.string(v)],
+                    expected: .success(false)
+                ))
+        }
+        // Non-string inputs return false rather than a type error
+        for (typeName, value): (String, AST.RegoValue) in [
+            ("number", 123), ("boolean", false), ("null", .null),
+            ("array", [1, 2, 3]), ("object", ["a": 1]), ("set", .set([1])),
+        ] {
+            cases.append(
+                BuiltinTests.TestCase(
+                    description: "is_valid: false for \(typeName)",
+                    name: "semver.is_valid",
+                    args: [value],
+                    expected: .success(false)
+                ))
+        }
+        return cases
+    }
+
+    // MARK: - All Tests
+    static var allTests: [BuiltinTests.TestCase] {
+        [
+            BuiltinTests.generateNumberOfArgumentsFailureTests(
+                builtinName: "semver.is_valid", sampleArgs: ["1.0.0"]),
+            BuiltinTests.generateFailureTests(
+                builtinName: "semver.compare", sampleArgs: ["1.0.0", "2.0.0"], argIndex: 0,
+                argName: "a", allowedArgTypes: ["string"],
+                generateNumberOfArgsTest: true, numberAsInteger: false),
+            BuiltinTests.generateFailureTests(
+                builtinName: "semver.compare", sampleArgs: ["1.0.0", "2.0.0"], argIndex: 1,
+                argName: "b", allowedArgTypes: ["string"],
+                generateNumberOfArgsTest: false, numberAsInteger: false),
+            otherCompareTests,
+            isValidTests,
+            compareTests,
+        ].flatMap { $0 }
+    }
+
+    @Test(arguments: allTests)
+    func testBuiltins(tc: BuiltinTests.TestCase) async throws {
+        try await BuiltinTests.testBuiltin(tc: tc)
+    }
+}

--- a/capabilities.json
+++ b/capabilities.json
@@ -1425,6 +1425,37 @@
       "decl" : {
         "args" : [
           {
+            "type" : "string"
+          },
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
+          "type" : "number"
+        },
+        "type" : "function"
+      },
+      "name" : "semver.compare"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "type" : "boolean"
+        },
+        "type" : "function"
+      },
+      "name" : "semver.is_valid"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
             "of" : [
               {
                 "dynamic" : {


### PR DESCRIPTION

### What code changed, and why?
This change implements `semver.compare` and `semver.is_valid` builtins, and ensures that SemVer compliance tests pass.

### Definition of done
* Comprehensive unit tests coverage mimicking [OPA](https://github.com/open-policy-agent/opa/blob/main/internal/semver/semver_test.go)
* Compliance Tests pass:
```
✅ semvercompare/test-semvercompare-0348.json: semvercompare/invalid version b -> eval
✅ semvercompare/test-semvercompare-0347.json: semvercompare/invalid version a -> eval
✅ semverisvalid/test-semverisvalid-0351.json: semverisvalid/invalid type -> eval
✅ semverisvalid/test-semverisvalid-0350.json: semverisvalid/invalid version -> eval
✅ semvercompare/test-semvercompare-0345.json: semvercompare/a > b -> eval
✅ semverisvalid/test-semverisvalid-0349.json: semverisvalid/valid -> eval
✅ semvercompare/test-semvercompare-0346.json: semvercompare/a == b -> eval
✅ semvercompare/test-semvercompare-0344.json: semvercompare/a < b -> eval
```

### How to test
```
make generate all
OPA_COMPLIANCE_TESTS="semver" make test-compliance
```

### Related Resources
Resolves #122
