### PR TITLE
IR+StaticAnalysis: Add locals renumbering pass

### DIFF
--- a/Sources/IR/IR+Decode.swift
+++ b/Sources/IR/IR+Decode.swift
@@ -15,15 +15,31 @@ extension Policy {
     /// Prepare the policy for execution by running static analysis passes.
     /// This computes properties like maxLocal that are used for optimization.
     public mutating func prepareForExecution() throws {
-        // Compute maxLocal for all plans
+        // Renumber locals in every plan and func to compact contiguous ranges.
+        if var plans = self.plans {
+            for i in plans.plans.indices {
+                plans.plans[i].renumberLocals()
+            }
+            self.plans = plans
+        }
+        if var funcs = self.funcs {
+            if var funcList = funcs.funcs {
+                for i in funcList.indices {
+                    funcList[i].renumberLocals()
+                }
+                funcs.funcs = funcList
+            }
+            self.funcs = funcs
+        }
+
+        // Compute maxLocal after renumbering so the cached value reflects the
+        // compacted range used by the evaluator.
         if var plans = self.plans {
             for i in plans.plans.indices {
                 plans.plans[i].computeMaxLocal()
             }
             self.plans = plans
         }
-
-        // Compute maxLocal for all functions
         if var funcs = self.funcs {
             if var funcList = funcs.funcs {
                 for i in funcList.indices {

--- a/Sources/IR/IR+StaticAnalysis.swift
+++ b/Sources/IR/IR+StaticAnalysis.swift
@@ -1,3 +1,4 @@
+import AST
 import Foundation
 
 // MARK: - IR Errors
@@ -57,7 +58,55 @@ extension Statement {
     }
 }
 
+// MARK: - Locals Renumbering
+//
+// Renumbering compacts sparse local indices into a contiguous range so the
+// evaluator can pre-allocate locals storage without wasting slots. The pass is
+// designed to be:
+//
+// - Stable: original indices are remapped in sorted order, so remappings
+//   preserve relative ordering.
+// - Idempotent: running the pass twice produces the same result as once.
+// - A no-op for already-compact plans/funcs. When the mapping is the same
+//   as what's already there, no rewrite happens.
+//
+// Plans treat locals 0 (input) and 1 (data) as reserved. Funcs treat their
+// declared params and returnVar as reserved (kept at their original indices),
+// since callers reference those positions when invoking the func.
+
 extension Plan {
+    public mutating func renumberLocals() {
+        let remapping = buildPlanRemapping()
+        guard !isIdentity(remapping) else { return }
+        for i in blocks.indices {
+            blocks[i].walk { statement in
+                statement.applyLocalRemapping(remapping)
+            }
+        }
+    }
+
+    private func buildPlanRemapping() -> [Int: Int] {
+        var allLocals = Set<Int>()
+        for var block in blocks {
+            block.walk { statement in
+                statement.collectLocals(into: &allLocals)
+            }
+        }
+        // Reserved: 0 (input), 1 (data) are conventionally fixed for plans.
+        let reserved: Set<Int> = [0, 1]
+        var remapping: [Int: Int] = [:]
+        for r in reserved {
+            remapping[r] = r
+        }
+        let sortedNonReserved = allLocals.subtracting(reserved).sorted()
+        var nextAvail = 2
+        for orig in sortedNonReserved {
+            remapping[orig] = nextAvail
+            nextAvail += 1
+        }
+        return remapping
+    }
+
     public mutating func computeMaxLocal() {
         var maxLocal = -1
         for i in blocks.indices {
@@ -70,6 +119,48 @@ extension Plan {
 }
 
 extension Func {
+    public mutating func renumberLocals() {
+        let remapping = buildFuncRemapping()
+        guard !isIdentity(remapping) else { return }
+        for i in blocks.indices {
+            blocks[i].walk { statement in
+                statement.applyLocalRemapping(remapping)
+            }
+        }
+    }
+
+    private func buildFuncRemapping() -> [Int: Int] {
+        var allLocals = Set<Int>()
+        for var block in blocks {
+            block.walk { statement in
+                statement.collectLocals(into: &allLocals)
+            }
+        }
+        // Reserved: params and returnVar are kept at their original indices since
+        // callers reference these positions to pass arguments and read the result.
+        var reserved: Set<Int> = Set(params.map { Int($0) })
+        reserved.insert(Int(returnVar))
+        // Reserved are part of the func's used locals even if they don't appear
+        // in any statement.
+        allLocals.formUnion(reserved)
+
+        var remapping: [Int: Int] = [:]
+        for r in reserved {
+            remapping[r] = r
+        }
+        let sortedNonReserved = allLocals.subtracting(reserved).sorted()
+        // Fill the lowest indices that aren't reserved.
+        var nextAvail = 0
+        for orig in sortedNonReserved {
+            while reserved.contains(nextAvail) {
+                nextAvail += 1
+            }
+            remapping[orig] = nextAvail
+            nextAvail += 1
+        }
+        return remapping
+    }
+
     public mutating func computeMaxLocal() {
         var maxLocal = -1
 
@@ -88,7 +179,240 @@ extension Func {
     }
 }
 
+private func isIdentity(_ remapping: [Int: Int]) -> Bool {
+    for (k, v) in remapping where k != v {
+        return false
+    }
+    return true
+}
+
 extension Statement {
+    /// Collect every local index referenced by this statement into `locals`.
+    /// Does not descend into nested blocks, as Block.walk handles recursion.
+    func collectLocals(into locals: inout Set<Int>) {
+        switch self {
+        case .arrayAppendStmt(let stmt):
+            locals.insert(Int(stmt.array))
+            collectOperandLocal(stmt.value, into: &locals)
+        case .assignIntStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .assignVarStmt(let stmt):
+            locals.insert(Int(stmt.target))
+            collectOperandLocal(stmt.source, into: &locals)
+        case .assignVarOnceStmt(let stmt):
+            locals.insert(Int(stmt.target))
+            collectOperandLocal(stmt.source, into: &locals)
+        case .callStmt(let stmt):
+            locals.insert(Int(stmt.result))
+            for arg in stmt.args ?? [] {
+                collectOperandLocal(arg, into: &locals)
+            }
+        case .callDynamicStmt(let stmt):
+            locals.insert(Int(stmt.result))
+            for arg in stmt.args {
+                locals.insert(Int(arg))
+            }
+            for pathOp in stmt.path {
+                collectOperandLocal(pathOp, into: &locals)
+            }
+        case .dotStmt(let stmt):
+            locals.insert(Int(stmt.target))
+            collectOperandLocal(stmt.source, into: &locals)
+            collectOperandLocal(stmt.key, into: &locals)
+        case .equalStmt(let stmt):
+            collectOperandLocal(stmt.a, into: &locals)
+            collectOperandLocal(stmt.b, into: &locals)
+        case .isArrayStmt(let stmt):
+            collectOperandLocal(stmt.source, into: &locals)
+        case .isDefinedStmt(let stmt):
+            locals.insert(Int(stmt.source))
+        case .isObjectStmt(let stmt):
+            collectOperandLocal(stmt.source, into: &locals)
+        case .isSetStmt(let stmt):
+            collectOperandLocal(stmt.source, into: &locals)
+        case .isUndefinedStmt(let stmt):
+            locals.insert(Int(stmt.source))
+        case .lenStmt(let stmt):
+            locals.insert(Int(stmt.target))
+            collectOperandLocal(stmt.source, into: &locals)
+        case .makeArrayStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .makeNullStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .makeNumberIntStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .makeNumberRefStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .makeObjectStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .makeSetStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .notEqualStmt(let stmt):
+            collectOperandLocal(stmt.a, into: &locals)
+            collectOperandLocal(stmt.b, into: &locals)
+        case .objectInsertStmt(let stmt):
+            locals.insert(Int(stmt.object))
+            collectOperandLocal(stmt.key, into: &locals)
+            collectOperandLocal(stmt.value, into: &locals)
+        case .objectInsertOnceStmt(let stmt):
+            locals.insert(Int(stmt.object))
+            collectOperandLocal(stmt.key, into: &locals)
+            collectOperandLocal(stmt.value, into: &locals)
+        case .objectMergeStmt(let stmt):
+            locals.insert(Int(stmt.a))
+            locals.insert(Int(stmt.b))
+            locals.insert(Int(stmt.target))
+        case .resetLocalStmt(let stmt):
+            locals.insert(Int(stmt.target))
+        case .resultSetAddStmt(let stmt):
+            locals.insert(Int(stmt.value))
+        case .returnLocalStmt(let stmt):
+            locals.insert(Int(stmt.source))
+        case .scanStmt(let stmt):
+            locals.insert(Int(stmt.source))
+            locals.insert(Int(stmt.key))
+            locals.insert(Int(stmt.value))
+        case .setAddStmt(let stmt):
+            locals.insert(Int(stmt.set))
+            collectOperandLocal(stmt.value, into: &locals)
+        case .withStmt(let stmt):
+            locals.insert(Int(stmt.local))
+            collectOperandLocal(stmt.value, into: &locals)
+        case .breakStmt, .nopStmt, .blockStmt, .notStmt, .unknown:
+            break
+        }
+    }
+
+    /// Apply a precomputed local-index remapping to every local reference in
+    /// this statement. Indices not present in the map are left unchanged.
+    /// Does not descend into nested blocks, as Block.walk handles recursion.
+    mutating func applyLocalRemapping(_ remapping: [Int: Int]) {
+        switch self {
+        case .arrayAppendStmt(var stmt):
+            stmt.array = Local(remap(Int(stmt.array), remapping))
+            remapOperand(&stmt.value, remapping)
+            self = .arrayAppendStmt(stmt)
+        case .assignIntStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .assignIntStmt(stmt)
+        case .assignVarStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            remapOperand(&stmt.source, remapping)
+            self = .assignVarStmt(stmt)
+        case .assignVarOnceStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            remapOperand(&stmt.source, remapping)
+            self = .assignVarOnceStmt(stmt)
+        case .callStmt(var stmt):
+            stmt.result = Local(remap(Int(stmt.result), remapping))
+            if var args = stmt.args {
+                for i in args.indices {
+                    remapOperand(&args[i], remapping)
+                }
+                stmt.args = args
+            }
+            self = .callStmt(stmt)
+        case .callDynamicStmt(var stmt):
+            stmt.result = Local(remap(Int(stmt.result), remapping))
+            for i in stmt.args.indices {
+                stmt.args[i] = Local(remap(Int(stmt.args[i]), remapping))
+            }
+            for i in stmt.path.indices {
+                remapOperand(&stmt.path[i], remapping)
+            }
+            self = .callDynamicStmt(stmt)
+        case .dotStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            remapOperand(&stmt.source, remapping)
+            remapOperand(&stmt.key, remapping)
+            self = .dotStmt(stmt)
+        case .equalStmt(var stmt):
+            remapOperand(&stmt.a, remapping)
+            remapOperand(&stmt.b, remapping)
+            self = .equalStmt(stmt)
+        case .isArrayStmt(var stmt):
+            remapOperand(&stmt.source, remapping)
+            self = .isArrayStmt(stmt)
+        case .isDefinedStmt(var stmt):
+            stmt.source = Local(remap(Int(stmt.source), remapping))
+            self = .isDefinedStmt(stmt)
+        case .isObjectStmt(var stmt):
+            remapOperand(&stmt.source, remapping)
+            self = .isObjectStmt(stmt)
+        case .isSetStmt(var stmt):
+            remapOperand(&stmt.source, remapping)
+            self = .isSetStmt(stmt)
+        case .isUndefinedStmt(var stmt):
+            stmt.source = Local(remap(Int(stmt.source), remapping))
+            self = .isUndefinedStmt(stmt)
+        case .lenStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            remapOperand(&stmt.source, remapping)
+            self = .lenStmt(stmt)
+        case .makeArrayStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .makeArrayStmt(stmt)
+        case .makeNullStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .makeNullStmt(stmt)
+        case .makeNumberIntStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .makeNumberIntStmt(stmt)
+        case .makeNumberRefStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .makeNumberRefStmt(stmt)
+        case .makeObjectStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .makeObjectStmt(stmt)
+        case .makeSetStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .makeSetStmt(stmt)
+        case .notEqualStmt(var stmt):
+            remapOperand(&stmt.a, remapping)
+            remapOperand(&stmt.b, remapping)
+            self = .notEqualStmt(stmt)
+        case .objectInsertStmt(var stmt):
+            stmt.object = Local(remap(Int(stmt.object), remapping))
+            remapOperand(&stmt.key, remapping)
+            remapOperand(&stmt.value, remapping)
+            self = .objectInsertStmt(stmt)
+        case .objectInsertOnceStmt(var stmt):
+            stmt.object = Local(remap(Int(stmt.object), remapping))
+            remapOperand(&stmt.key, remapping)
+            remapOperand(&stmt.value, remapping)
+            self = .objectInsertOnceStmt(stmt)
+        case .objectMergeStmt(var stmt):
+            stmt.a = Local(remap(Int(stmt.a), remapping))
+            stmt.b = Local(remap(Int(stmt.b), remapping))
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .objectMergeStmt(stmt)
+        case .resetLocalStmt(var stmt):
+            stmt.target = Local(remap(Int(stmt.target), remapping))
+            self = .resetLocalStmt(stmt)
+        case .resultSetAddStmt(var stmt):
+            stmt.value = Local(remap(Int(stmt.value), remapping))
+            self = .resultSetAddStmt(stmt)
+        case .returnLocalStmt(var stmt):
+            stmt.source = Local(remap(Int(stmt.source), remapping))
+            self = .returnLocalStmt(stmt)
+        case .scanStmt(var stmt):
+            stmt.source = Local(remap(Int(stmt.source), remapping))
+            stmt.key = Local(remap(Int(stmt.key), remapping))
+            stmt.value = Local(remap(Int(stmt.value), remapping))
+            self = .scanStmt(stmt)
+        case .setAddStmt(var stmt):
+            stmt.set = Local(remap(Int(stmt.set), remapping))
+            remapOperand(&stmt.value, remapping)
+            self = .setAddStmt(stmt)
+        case .withStmt(var stmt):
+            stmt.local = Local(remap(Int(stmt.local), remapping))
+            remapOperand(&stmt.value, remapping)
+            self = .withStmt(stmt)
+        case .breakStmt, .nopStmt, .blockStmt, .notStmt, .unknown:
+            break
+        }
+    }
+
     func maxLocalUsed() -> Int {
         var maxLocal = -1
 
@@ -197,6 +521,24 @@ extension Statement {
             return -1
         }
     }
+}
+
+// MARK: - Renumbering helpers
+
+private func collectOperandLocal(_ operand: Operand, into locals: inout Set<Int>) {
+    if case .localIndex(let idx) = operand.value {
+        locals.insert(idx)
+    }
+}
+
+private func remapOperand(_ operand: inout Operand, _ remapping: [Int: Int]) {
+    if case .localIndex(let idx) = operand.value {
+        operand.value = .localIndex(remap(idx, remapping))
+    }
+}
+
+private func remap(_ idx: Int, _ remapping: [Int: Int]) -> Int {
+    return remapping[idx] ?? idx
 }
 
 // MARK: - Static String Resolution

--- a/Sources/Rego/VM.swift
+++ b/Sources/Rego/VM.swift
@@ -169,7 +169,9 @@ extension VM {
                 return BlockResult(breakCounter: UInt32(length))
             case Int(Opcode.assignVar1.rawValue):
                 // Payload is [target:12 | source:12] packed in the header length field.
-                context.locals[Local(UInt32(length) >> 12)] = context.locals[Local(UInt32(length) & 0xFFF)]
+                // Read through resolveLocal so an unbound source is promoted to .undefined,
+                // matching the non-compact assignVar path.
+                context.locals[Local(UInt32(length) >> 12)] = context.resolveLocal(idx: Local(UInt32(length) & 0xFFF))
                 continue
             // ── Non-compact opcodes (rawValues 0–34): `length` is payload byte count ─────────
             // Assignments

--- a/Tests/IRTests/IRStaticAnalysisTests.swift
+++ b/Tests/IRTests/IRStaticAnalysisTests.swift
@@ -1,0 +1,424 @@
+import AST
+import Foundation
+import Testing
+
+@testable import IR
+
+@Suite("IRRenumberingTests")
+struct IRRenumberingTests {
+
+    struct TestCase {
+        var name: String
+        var policy: Policy
+        var result: Policy
+    }
+
+    // Helpers to keep the cases concise.
+    private static func op(_ idx: Int) -> Operand {
+        Operand(type: .local, value: .localIndex(idx))
+    }
+    private static func strOp(_ idx: Int) -> Operand {
+        Operand(type: .stringIndex, value: .stringIndex(idx))
+    }
+    private static func plan(_ name: String, _ stmts: [Statement]) -> Plan {
+        Plan(name: name, blocks: [Block(statements: stmts)])
+    }
+    private static func fn(
+        _ name: String,
+        params: [Local],
+        returnVar: Local,
+        _ stmts: [Statement]
+    ) -> Func {
+        Func(
+            name: name, path: name.split(separator: "/").map(String.init), params: params, returnVar: returnVar,
+            blocks: [Block(statements: stmts)])
+    }
+    private static func staticData(strings: Int = 0, files: Int = 1) -> Static {
+        Static(
+            strings: (0..<strings).map { ConstString(value: "s\($0)") },
+            files: (0..<files).map { ConstString(value: "f\($0).rego") }
+        )
+    }
+
+    static let testcases: [TestCase] = [
+        // Original case: a sparse Local(2000) is compacted down to Local(4).
+        TestCase(
+            name: "simple correct",
+            policy: Policy(
+                staticData: staticData(strings: 3),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/hello",
+                        [
+                            .callStmt(
+                                CallStatement(
+                                    location: Location(row: 0, col: 8, file: 9),
+                                    callFunc: "g0.data.policy.hello",
+                                    args: [op(0), op(1)],
+                                    result: Local(2)
+                                )),
+                            .assignVarStmt(
+                                AssignVarStatement(
+                                    location: Location(row: 1, col: 2, file: 3),
+                                    source: op(2),
+                                    target: Local(3)
+                                )),
+                            .makeObjectStmt(MakeObjectStatement(target: Local(2000))),
+                            .objectInsertStmt(
+                                ObjectInsertStatement(
+                                    key: strOp(0),
+                                    value: op(3),
+                                    object: Local(2000)
+                                )),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(2000))),
+                        ])
+                ])
+            ),
+            result: Policy(
+                staticData: staticData(strings: 3),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/hello",
+                        [
+                            .callStmt(
+                                CallStatement(
+                                    location: Location(row: 0, col: 8, file: 9),
+                                    callFunc: "g0.data.policy.hello",
+                                    args: [op(0), op(1)],
+                                    result: Local(2)
+                                )),
+                            .assignVarStmt(
+                                AssignVarStatement(
+                                    location: Location(row: 1, col: 2, file: 3),
+                                    source: op(2),
+                                    target: Local(3)
+                                )),
+                            .makeObjectStmt(MakeObjectStatement(target: Local(4))),
+                            .objectInsertStmt(
+                                ObjectInsertStatement(
+                                    key: strOp(0),
+                                    value: op(3),
+                                    object: Local(4)
+                                )),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(4))),
+                        ])
+                ])
+            )
+        ),
+
+        // Already-compact plan: pass should be a no-op.
+        TestCase(
+            name: "no-op identity for already-compact plan",
+            policy: Policy(
+                staticData: staticData(),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/identity",
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(2))),
+                            .assignVarStmt(
+                                AssignVarStatement(source: op(2), target: Local(3))
+                            ),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(3))),
+                        ])
+                ])
+            ),
+            result: Policy(
+                staticData: staticData(),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/identity",
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(2))),
+                            .assignVarStmt(
+                                AssignVarStatement(source: op(2), target: Local(3))
+                            ),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(3))),
+                        ])
+                ])
+            )
+        ),
+
+        // Multiple sparse locals are compacted in sorted order, preserving relative
+        // order and packing into [2, 3, 4] after the reserved input/data slots.
+        TestCase(
+            name: "multiple sparse locals compact in sorted order",
+            policy: Policy(
+                staticData: staticData(),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/sparse",
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(50))),
+                            .makeObjectStmt(MakeObjectStatement(target: Local(100))),
+                            .assignVarStmt(
+                                AssignVarStatement(source: op(50), target: Local(200))
+                            ),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(100))),
+                        ])
+                ])
+            ),
+            result: Policy(
+                staticData: staticData(),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/sparse",
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(2))),
+                            .makeObjectStmt(MakeObjectStatement(target: Local(3))),
+                            .assignVarStmt(
+                                AssignVarStatement(source: op(2), target: Local(4))
+                            ),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(3))),
+                        ])
+                ])
+            )
+        ),
+
+        // Renumbering walks into nested blocks (scan body, with body, not body).
+        TestCase(
+            name: "nested blocks: scan/with/not bodies are renumbered",
+            policy: Policy(
+                staticData: staticData(strings: 1),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/nested",
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(500))),
+                            .scanStmt(
+                                ScanStatement(
+                                    source: Local(500),
+                                    key: Local(501),
+                                    value: Local(502),
+                                    block: Block(statements: [
+                                        .objectInsertStmt(
+                                            ObjectInsertStatement(
+                                                key: op(501),
+                                                value: op(502),
+                                                object: Local(500)
+                                            ))
+                                    ])
+                                )),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(500))),
+                        ])
+                ])
+            ),
+            result: Policy(
+                staticData: staticData(strings: 1),
+                plans: Plans(plans: [
+                    plan(
+                        "policy/nested",
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(2))),
+                            .scanStmt(
+                                ScanStatement(
+                                    source: Local(2),
+                                    key: Local(3),
+                                    value: Local(4),
+                                    block: Block(statements: [
+                                        .objectInsertStmt(
+                                            ObjectInsertStatement(
+                                                key: op(3),
+                                                value: op(4),
+                                                object: Local(2)
+                                            ))
+                                    ])
+                                )),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(2))),
+                        ])
+                ])
+            )
+        ),
+
+        // Func with conventional params [0,1] / returnVar 2 keeps its interface
+        // and compacts other locals around it.
+        TestCase(
+            name: "func compacts non-reserved locals; preserves params/returnVar",
+            policy: Policy(
+                staticData: staticData(strings: 2),
+                funcs: Funcs(funcs: [
+                    fn(
+                        "g0/hello", params: [Local(0), Local(1)], returnVar: Local(2),
+                        [
+                            .resetLocalStmt(ResetLocalStatement(target: Local(99))),
+                            .makeNumberRefStmt(MakeNumberRefStatement(index: 1, target: Local(100))),
+                            .assignVarOnceStmt(
+                                AssignVarOnceStatement(source: op(100), target: Local(99))
+                            ),
+                            .isDefinedStmt(IsDefinedStatement(source: Local(99))),
+                            .assignVarOnceStmt(
+                                AssignVarOnceStatement(source: op(99), target: Local(2))
+                            ),
+                            .returnLocalStmt(ReturnLocalStatement(source: Local(2))),
+                        ])
+                ])
+            ),
+            result: Policy(
+                staticData: staticData(strings: 2),
+                funcs: Funcs(funcs: [
+                    fn(
+                        "g0/hello", params: [Local(0), Local(1)], returnVar: Local(2),
+                        [
+                            .resetLocalStmt(ResetLocalStatement(target: Local(3))),
+                            .makeNumberRefStmt(MakeNumberRefStatement(index: 1, target: Local(4))),
+                            .assignVarOnceStmt(
+                                AssignVarOnceStatement(source: op(4), target: Local(3))
+                            ),
+                            .isDefinedStmt(IsDefinedStatement(source: Local(3))),
+                            .assignVarOnceStmt(
+                                AssignVarOnceStatement(source: op(3), target: Local(2))
+                            ),
+                            .returnLocalStmt(ReturnLocalStatement(source: Local(2))),
+                        ])
+                ])
+            )
+        ),
+
+        // Func with unconventional params: reserved indices are preserved,
+        // other locals fill the lowest non-reserved indices.
+        TestCase(
+            name: "func with unconventional params: reserved indices preserved",
+            policy: Policy(
+                staticData: staticData(),
+                funcs: Funcs(funcs: [
+                    fn(
+                        "g0/oddparams", params: [Local(3), Local(5)], returnVar: Local(7),
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(20))),
+                            .assignVarOnceStmt(
+                                AssignVarOnceStatement(source: op(20), target: Local(7))
+                            ),
+                            .returnLocalStmt(ReturnLocalStatement(source: Local(7))),
+                        ])
+                ])
+            ),
+            // Reserved = {3, 5, 7}.  Other locals (just 20) fill the lowest
+            // non-reserved slot, which is 0.
+            result: Policy(
+                staticData: staticData(),
+                funcs: Funcs(funcs: [
+                    fn(
+                        "g0/oddparams", params: [Local(3), Local(5)], returnVar: Local(7),
+                        [
+                            .makeObjectStmt(MakeObjectStatement(target: Local(0))),
+                            .assignVarOnceStmt(
+                                AssignVarOnceStatement(source: op(0), target: Local(7))
+                            ),
+                            .returnLocalStmt(ReturnLocalStatement(source: Local(7))),
+                        ])
+                ])
+            )
+        ),
+    ]
+
+    @Test(arguments: testcases)
+    func testRenumber(tc: IRRenumberingTests.TestCase) async throws {
+        var policy = tc.policy
+        try policy.prepareForExecution()
+
+        let gotPlans = policy.plans?.plans ?? []
+        let wantPlans = tc.result.plans?.plans ?? []
+        #expect(gotPlans.count == wantPlans.count, "plan count")
+        for (got, want) in zip(gotPlans, wantPlans) {
+            #expect(got.name == want.name)
+            #expect(got.blocks == want.blocks, "plan '\(want.name)' blocks differ")
+        }
+
+        let gotFuncs = policy.funcs?.funcs ?? []
+        let wantFuncs = tc.result.funcs?.funcs ?? []
+        #expect(gotFuncs.count == wantFuncs.count, "func count")
+        for (got, want) in zip(gotFuncs, wantFuncs) {
+            #expect(got.name == want.name)
+            #expect(got.params == want.params, "func '\(want.name)' params differ")
+            #expect(got.returnVar == want.returnVar, "func '\(want.name)' returnVar differs")
+            #expect(got.blocks == want.blocks, "func '\(want.name)' blocks differ")
+        }
+    }
+
+    // The renumbering pass should be idempotent across runs.
+    @Test(arguments: testcases)
+    func testIdempotent(tc: IRRenumberingTests.TestCase) async throws {
+        var once = tc.policy
+        try once.prepareForExecution()
+
+        var twice = tc.policy
+        try twice.prepareForExecution()
+        try twice.prepareForExecution()
+
+        let oncePlans = once.plans?.plans ?? []
+        let twicePlans = twice.plans?.plans ?? []
+        for (a, b) in zip(oncePlans, twicePlans) {
+            #expect(a.blocks == b.blocks, "plan '\(a.name)' diverged after second pass")
+        }
+
+        let onceFuncs = once.funcs?.funcs ?? []
+        let twiceFuncs = twice.funcs?.funcs ?? []
+        for (a, b) in zip(onceFuncs, twiceFuncs) {
+            #expect(a.blocks == b.blocks, "func '\(a.name)' diverged after second pass")
+            #expect(a.params == b.params, "func '\(a.name)' params diverged after second pass")
+            #expect(a.returnVar == b.returnVar, "func '\(a.name)' returnVar diverged after second pass")
+        }
+    }
+
+    // Decode an OPA-compiled plan from JSON and verify the renumbering pass
+    // leaves an already-compact, real-world policy unchanged.  This guards
+    // against regressions where decoding + prepareForExecution might mangle
+    // statements that don't need rewriting.
+    @Test
+    func testRealOPAPlanIsNoOp() async throws {
+        let json = #"""
+            {
+              "static": {
+                "strings": [{"value":"result"},{"value":"1"}],
+                "files": [{"value":"bar.rego"}]
+              },
+              "plans": {"plans": [{"name":"foo/hello","blocks":[{"stmts":[
+                {"type":"CallStmt","stmt":{"func":"g0.data.foo.hello","args":[{"type":"local","value":0},{"type":"local","value":1}],"result":2,"file":0,"col":0,"row":0}},
+                {"type":"AssignVarStmt","stmt":{"source":{"type":"local","value":2},"target":3,"file":0,"col":0,"row":0}},
+                {"type":"MakeObjectStmt","stmt":{"target":4,"file":0,"col":0,"row":0}},
+                {"type":"ObjectInsertStmt","stmt":{"key":{"type":"string_index","value":0},"value":{"type":"local","value":3},"object":4,"file":0,"col":0,"row":0}},
+                {"type":"ResultSetAddStmt","stmt":{"value":4,"file":0,"col":0,"row":0}}
+              ]}]}]},
+              "funcs": {"funcs": [{"name":"g0.data.foo.hello","params":[0,1],"return":2,"blocks":[
+                {"stmts":[
+                  {"type":"ResetLocalStmt","stmt":{"target":3,"file":0,"col":1,"row":3}},
+                  {"type":"MakeNumberRefStmt","stmt":{"Index":1,"target":4,"file":0,"col":1,"row":3}},
+                  {"type":"AssignVarOnceStmt","stmt":{"source":{"type":"local","value":4},"target":3,"file":0,"col":1,"row":3}}
+                ]},
+                {"stmts":[
+                  {"type":"IsDefinedStmt","stmt":{"source":3,"file":0,"col":1,"row":3}},
+                  {"type":"AssignVarOnceStmt","stmt":{"source":{"type":"local","value":3},"target":2,"file":0,"col":1,"row":3}}
+                ]},
+                {"stmts":[
+                  {"type":"ReturnLocalStmt","stmt":{"source":2,"file":0,"col":1,"row":3}}
+                ]}
+              ],"path":["g0","foo","hello"]}]}
+            }
+            """#
+        // Decode raw (without prepareForExecution).
+        let raw = try JSONDecoder().decode(Policy.self, from: Data(json.utf8))
+        // Decode + prepareForExecution (this runs renumbering).
+        let prepared = try Policy(jsonData: Data(json.utf8))
+
+        // Plans/funcs should be byte-for-byte identical: the input is already
+        // compact, so the pass should not rewrite anything.
+        let rawPlans = raw.plans?.plans ?? []
+        let preparedPlans = prepared.plans?.plans ?? []
+        for (r, p) in zip(rawPlans, preparedPlans) {
+            #expect(r.blocks == p.blocks, "plan '\(r.name)' was unexpectedly rewritten")
+        }
+        let rawFuncs = raw.funcs?.funcs ?? []
+        let preparedFuncs = prepared.funcs?.funcs ?? []
+        for (r, p) in zip(rawFuncs, preparedFuncs) {
+            #expect(r.blocks == p.blocks, "func '\(r.name)' was unexpectedly rewritten")
+        }
+
+        // maxLocal should be set after preparation.
+        #expect(preparedPlans.first?.maxLocal == 4)
+        #expect(preparedFuncs.first?.maxLocal == 4)
+    }
+}
+
+extension IRRenumberingTests.TestCase: CustomTestStringConvertible {
+    var testDescription: String { name }
+}


### PR DESCRIPTION
### What code changed, and why?

This PR adds a renumbering pass to our IR static analysis that ensures all locals in a policy's IR statements are of a contiguous range.

This prevents cases where a local is set to a random large value (e.g. 1234567) from hurting our locals preallocation in the evaluator. After renumbering a plan or func, the max local index in its IR statements will be equal to the number of unique locals present in that plan or func.

We can prealloc the locals array in peace now! 😅 

~~Note: The current test case is ugly as heck, and large, due to the size of the `Policy` type initializers. I'll see about cleaning it up a bit, possibly by converting the `Policy` arguments to JSON, and just adding some comments about what's different between the input and expected result.~~

Note 2: It may be worth merging the renumbering and `maxLocal` logic together. @koponen, let me know if you think it's worthwhile.

Fixes: #115

---

Update: I wound up reworking this PR to the 2-pass algorithm, because the encounter-ordering of the 1-pass algorithm resulted in some very arbitrary remapping, and resulted in needless churn, even on "compact" (already contiguous locals) IR policies.

### Definition of done

 - Renumbering works.
 - "Easy" test cases work.
 - [x] Add an edge case test or two?

### How to test

 - There's a new test suite under `Tests/IRTests/IRStaticAnalysisTests.swift`. This is picked up automatically by `make test`. 

### Related Resources

