### PR TITLE
Rego/Manifest: Add `Codable` implementation.

### DIFF
--- a/Sources/Rego/Bundle.swift
+++ b/Sources/Rego/Bundle.swift
@@ -76,44 +76,7 @@ extension OPA.Manifest {
     /// Construct a manifest by parsing the provided JSON-encoded data.
     /// - Parameter jsonData: The JSON-encoded manifest data.
     public init(from jsonData: Data) throws {
-        let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
-        guard let jsonDict = jsonObject as? [String: Any] else {
-            throw DecodingError.typeMismatch(
-                [String: Any].self,
-                DecodingError.Context(codingPath: [], debugDescription: "Invalid JSON format"))
-        }
-
-        let revision = jsonDict["revision"] as? String ?? ""
-        self.revision = revision
-
-        var roots = jsonDict["roots"] as? [String] ?? [""]
-        if roots.isEmpty {
-            roots = [""]
-        }
-        self.roots = roots
-
-        let regoVersionInt = jsonDict["rego_version"] as? Int ?? 1
-        self.regoVersion =
-            switch regoVersionInt {
-            case 0:
-                .regoV0
-            case 1:
-                .regoV1
-            default:
-                throw DecodingError.dataCorrupted(
-                    DecodingError.Context(
-                        codingPath: [], debugDescription: "Unsupported Rego version"))
-            }
-
-        guard let metadataAny = jsonDict["metadata"] else {
-            // No metadata, use default
-            self.metadata = .null
-            return
-        }
-
-        // Parse metadata
-        let metadataValue = try AST.RegoValue(from: metadataAny)
-        self.metadata = metadataValue
+        self = try JSONDecoder().decode(Self.self, from: jsonData)
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/Rego/Manifest+Codable.swift
+++ b/Sources/Rego/Manifest+Codable.swift
@@ -1,0 +1,42 @@
+import AST
+import Foundation
+
+extension OPA.Manifest: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.revision = try container.decodeIfPresent(String.self, forKey: .revision) ?? ""
+
+        var roots = try container.decodeIfPresent([String].self, forKey: .roots) ?? [""]
+        if roots.isEmpty {
+            roots = [""]
+        }
+        self.roots = roots
+
+        let regoVersionInt = try container.decodeIfPresent(Int.self, forKey: .regoVersion) ?? 1
+        guard let version = Version(rawValue: regoVersionInt) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: container.codingPath + [CodingKeys.regoVersion],
+                    debugDescription: "Unsupported Rego version: \(regoVersionInt)"
+                )
+            )
+        }
+        self.regoVersion = version
+
+        self.metadata = try container.decodeIfPresent(AST.RegoValue.self, forKey: .metadata) ?? .null
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(revision, forKey: .revision)
+        try container.encode(roots, forKey: .roots)
+        try container.encode(regoVersion.rawValue, forKey: .regoVersion)
+
+        // omitempty: only encode metadata when non-null
+        if metadata != .null {
+            try container.encode(metadata, forKey: .metadata)
+        }
+    }
+}


### PR DESCRIPTION
### What code changed, and why?

This PR extends the `OPA.Manifest` type with a `Codable` implementation. This allows easily extending support for different structured data formats in the future (e.g. YAML).

As an example of how useful this is, our previously custom JSON decoding logic becomes a one-liner in the PR, and YAML support in the Swift OPA SDK will be similarly straightforward to add once this PR lands.

### How to test

 - Run existing Bundle test suite as part of `make test`. The new decoder-based logic works just as well as the original custom logic did.

### Related Resources

