### PR TITLE
Tracer: fix 'occured' -> 'occurred' in doc comments

### DIFF
--- a/Sources/Rego/Tracer.swift
+++ b/Sources/Rego/Tracer.swift
@@ -25,7 +25,7 @@ extension OPA.Trace {
         case note
     }
 
-    /// Describes the source location at which a trace event occured
+    /// Describes the source location at which a trace event occurred
     public struct Location: Codable, Hashable, Sendable {
         public var row: Int = 0
         public var col: Int = 0

--- a/Sources/Rego/Tracer.swift
+++ b/Sources/Rego/Tracer.swift
@@ -15,7 +15,7 @@ extension OPA.Trace {
         case note
     }
 
-    /// Describes the type of traceable operation that occured
+    /// Describes the type of traceable operation that occurred
     public enum Operation: String, Codable, Hashable, Sendable {
         // Subset of the Go OPA topdown trace op's, add more as needed
         case enter


### PR DESCRIPTION
Two doc comments in `Sources/Rego/Tracer.swift` (lines 19, 29) read `that occured`. Fixed to `occurred`. Comment-only change.