### PR TITLE
Engine: Fix bundle data merging. Add new cross-bundle tests.

### DIFF
--- a/Sources/Rego/Bundle.swift
+++ b/Sources/Rego/Bundle.swift
@@ -26,10 +26,10 @@ extension OPA {
             }
         }
 
-        // validate runs integrity checks on the bundle, such as
-        // verifying that all data is contained under the bundle roots.
-        // Because this can be an expensive check, it is not done at
-        // init time.
+        /// ``validate`` runs integrity checks on the bundle, such as
+        /// verifying that all data is contained under the bundle roots.
+        /// Because this can be an expensive check, it is not done at
+        /// init time.
         public func validate() throws(BundleError) {
             try OPA.Bundle.checkDataCoveredByRoots(data: self.data, roots: self.manifest.roots)
         }

--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -171,12 +171,58 @@ extension OPA.Engine {
             loadedBundles[path.name] = b
         }
 
-        // Verify correctness of this bundle set
+        // Verify correctness of this bundle set (no overlapping roots).
         try OPA.Bundle.checkBundlesForOverlap(bundleSet: loadedBundles)
 
-        // Patch all the bundle data into the data tree on the store
+        // Verify each bundle's data is contained under its roots.
+        for (name, bundle) in loadedBundles.sorted(by: { $0.key < $1.key }) {
+            do {
+                try bundle.validate()
+            } catch {
+                throw RegoError(
+                    code: .bundleLoadError,
+                    message: "failed to validate bundle \(name)",
+                    cause: error
+                )
+            }
+        }
+
+        // Write each bundle's data into the store at paths corresponding to
+        // the bundle's declared roots. `checkBundlesForOverlap` guarantees
+        // these root paths are disjoint across bundles, so the per-root
+        // writes below cannot collide — each bundle contributes only within
+        // the subtree it "owns".
+        //
+        // A bundle with no data under one of its roots simply writes nothing
+        // for that root (e.g. a policy-only bundle whose roots describe
+        // decision paths rather than data paths).
+        try await store.write(to: StoreKeyPath(["data"]), value: .object([:]))
         for (_, bundle) in loadedBundles.sorted(by: { $0.key < $1.key }) {
-            try await store.write(to: StoreKeyPath(["data"]), value: bundle.data)
+            let roots = bundle.manifest.roots
+            for root in roots.sorted() {
+                let rootSegments = root.split(separator: "/").map(String.init)
+
+                // Walk bundle.data down to the subtree the bundle actually
+                // contributes for this root. If any segment is missing or
+                // isn't an object, this bundle has nothing to contribute
+                // for this root and we skip.
+                var subtree: AST.RegoValue = bundle.data
+                var found = true
+                for segment in rootSegments {
+                    guard case .object(let obj) = subtree,
+                        let next = obj[.string(segment)]
+                    else {
+                        found = false
+                        break
+                    }
+                    subtree = next
+                }
+                guard found else { continue }
+
+                // Write the subtree at ["data"] + rootSegments.
+                let storePath = StoreKeyPath(["data"] + rootSegments)
+                try await store.write(to: storePath, value: subtree)
+            }
         }
 
         let evaluator: IREvaluator

--- a/Tests/RegoTests/BundleTests+CrossBundleData.swift
+++ b/Tests/RegoTests/BundleTests+CrossBundleData.swift
@@ -1,0 +1,245 @@
+import AST
+import Foundation
+import Testing
+
+@testable import Rego
+
+@Suite("BundleTests - Cross Bundle Data")
+struct BundleCrossBundleDataTests {
+
+    /// Builds a bundle that contains a plan referencing `data.<dataPath>` and
+    /// returning it as the result of the given decision. The bundle itself
+    /// contains NO data - the data is expected to come from a different bundle.
+    static func makePolicyOnlyBundle(
+        decisionPath: String,
+        dataPath: String,
+        bundleName: String = "custom_policy"
+    ) throws -> OPA.Bundle {
+        let revID = UUID().uuidString
+        // The policy bundle "owns" the decision path root, but NOT the data path root.
+        // This way the data can be provided by a separate bundle.
+        let roots = [decisionPath]
+        let manifest = OPA.Manifest(revision: revID, roots: roots)
+
+        let segments = dataPath.split(separator: "/").map(String.init)
+
+        // Build static strings:
+        //   index 0: "result" (object key for the result set).
+        //   indices 1..n: each path segment used as a DotStmt key.
+        var staticStrings: [String] = [#"{"value": "result"}"#]
+        for segment in segments {
+            staticStrings.append(#"{"value": "\#(segment)"}"#)
+        }
+
+        // Local 0: input, Local 1: data (per IR convention)
+        // Walk data via DotStmts, starting from local 1 (data root).
+        var stmts: [String] = []
+        var sourceLocalIdx = 1  // start at data root
+        var keyStrIdx = 1
+        var targetLocalIdx = 5
+        for _ in segments {
+            let dotStmt = #"""
+                {"type":"DotStmt","stmt":{"source":{"type":"local","value":\#(sourceLocalIdx)},"key":{"type":"string_index","value":\#(keyStrIdx)},"target":\#(targetLocalIdx),"file":0,"col":0,"row":0}}
+                """#
+            stmts.append(dotStmt)
+            sourceLocalIdx = targetLocalIdx
+            keyStrIdx += 1
+            targetLocalIdx += 1
+        }
+
+        // Assign final walked value to target local 2, then construct result object
+        stmts.append(
+            #"{"type":"AssignVarStmt","stmt":{"source":{"type":"local","value":\#(sourceLocalIdx)},"target":2,"file":0,"col":0,"row":0}}"#
+        )
+        stmts.append(
+            #"{"type":"MakeObjectStmt","stmt":{"target":4,"file":0,"col":0,"row":0}}"#
+        )
+        stmts.append(
+            #"{"type":"ObjectInsertStmt","stmt":{"key":{"type":"string_index","value":0},"value":{"type":"local","value":2},"object":4,"file":0,"col":0,"row":0}}"#
+        )
+        stmts.append(
+            #"{"type":"ResultSetAddStmt","stmt":{"value":4,"file":0,"col":0,"row":0}}"#
+        )
+
+        let planJSON = """
+            {
+                "static":{"strings":[\(staticStrings.joined(separator: ","))],"files":[{"value":"policy.rego"}]},
+                "plans":{"plans":[{"name":"\(decisionPath)","blocks":[{"stmts":[\(stmts.joined(separator: ","))]}]}]},
+                "funcs":{"funcs":[]}
+            }
+            """
+
+        return try makeExampleBundle(
+            manifest: manifest,
+            planFiles: [
+                Rego.BundleFile(
+                    url: URL(string: "/\(bundleName)/plan.json")!,
+                    data: planJSON.data(using: .utf8)!
+                )
+            ],
+            regoFiles: [],
+            // Explicitly no data! This bundle only ships the plan.
+            data: .object([:])
+        )
+    }
+
+    /// Builds a bundle that contains ONLY data at a given path - no plans, no rego.
+    static func makeDataOnlyBundle(
+        dataPath: String,
+        value: AST.RegoValue,
+        bundleName: String = "custom_data"
+    ) throws -> OPA.Bundle {
+        let segments = dataPath.split(separator: "/").map(String.init)
+
+        // Nest the value under each path segment
+        var nested: AST.RegoValue = value
+        for segment in segments.reversed() {
+            nested = .object([.string(segment): nested])
+        }
+
+        // The data bundle owns the data path root.
+        let roots = [segments.joined(separator: "/")]
+        let manifest = OPA.Manifest(revision: UUID().uuidString, roots: roots)
+
+        return try makeExampleBundle(
+            manifest: manifest,
+            planFiles: [],
+            regoFiles: [],
+            data: nested
+        )
+    }
+
+    @Test("Policy bundle can reference data from a separate data-only bundle")
+    func testCrossBundleDataReference() async throws {
+        let decisionPath = "example/allow"
+        let dataPath = "config/example/value"
+
+        let policyBundle = try Self.makePolicyOnlyBundle(
+            decisionPath: decisionPath,
+            dataPath: dataPath
+        )
+
+        let dataBundle = try Self.makeDataOnlyBundle(
+            dataPath: dataPath,
+            value: .number(5)
+        )
+
+        var engine = OPA.Engine(bundles: [
+            "custom_policy": policyBundle,
+            "custom_data": dataBundle,
+        ])
+        let pq = try await engine.prepareForEvaluation(query: "data/" + decisionPath)
+
+        let result = try await pq.evaluate(
+            input: .object([:])
+        )
+
+        let expected: AST.RegoValue = .object(["result": 5])
+        #expect(result == ResultSet([expected]))
+    }
+
+    @Test("Policy bundle evaluation fails when data bundle is missing")
+    func testMissingDataBundleFails() async throws {
+        let decisionPath = "example/allow"
+        let dataPath = "config/feature/enabled"
+
+        let policyBundle = try Self.makePolicyOnlyBundle(
+            decisionPath: decisionPath,
+            dataPath: dataPath
+        )
+
+        // Only register the policy bundle - no data bundle.
+        var engine = OPA.Engine(bundles: ["policy": policyBundle])
+        let pq = try await engine.prepareForEvaluation(query: "data/" + decisionPath)
+        let result = try await pq.evaluate(
+            input: .object([:])
+        )
+
+        #expect(result == ResultSet([]))  // Policy fails at runtime, returning undefined.
+    }
+
+    @Test("Bundle validation rejects data outside of declared roots")
+    func testBundleCannotWriteOutsideRoots() async throws {
+        // Data bundle declares root "config/example/value" but also happens
+        // to have data at `other/path`. Only the declared root's subtree
+        // should make it into the store.
+        let decisionPath = "example/allow"
+        let dataPath = "config/example/value"
+
+        let policyBundle = try Self.makePolicyOnlyBundle(
+            decisionPath: decisionPath, dataPath: dataPath
+        )
+
+        // Craft a data bundle whose bundle.data has extra keys outside its roots.
+        let segments = dataPath.split(separator: "/").map(String.init)
+        var nested: AST.RegoValue = .number(42)
+        for segment in segments.reversed() {
+            nested = .object([.string(segment): nested])
+        }
+        // Merge in an out-of-root key that should NOT end up in the store:
+        if case .object(var obj) = nested {
+            obj[.string("sneaky")] = .string("should-not-appear")
+            nested = .object(obj)
+        }
+        let manifest = OPA.Manifest(
+            revision: UUID().uuidString,
+            roots: [dataPath]
+        )
+        let dataBundle = try makeExampleBundle(
+            manifest: manifest, planFiles: [], regoFiles: [], data: nested
+        )
+
+        var engine = OPA.Engine(bundles: [
+            "custom_policy": policyBundle,
+            "custom_data": dataBundle,
+        ])
+
+        await #expect(throws: RegoError.self) {
+            _ = try await engine.prepareForEvaluation(query: "data/" + decisionPath)
+        }
+    }
+
+    @Test("Policy can query a prefix that merges data from sibling data bundles")
+    func testPrefixQueryAcrossSiblingDataBundles() async throws {
+        let decisionPath = "example/features"
+        let prefixPath = "config/features"
+
+        // Policy walks data.config.features - a prefix shared by both data
+        // bundles' roots - and returns the resulting object.
+        let policyBundle = try Self.makePolicyOnlyBundle(
+            decisionPath: decisionPath,
+            dataPath: prefixPath
+        )
+
+        // Two sibling data bundles, each owning a disjoint leaf under
+        // config/features. The engine should write each bundle's subtree
+        // at ["data", "config", "features", "<leaf>"], leaving the
+        // intermediate {config: {features: {...}}} branch shared.
+        let dataBundleA = try Self.makeDataOnlyBundle(
+            dataPath: "\(prefixPath)/a",
+            value: .string("alpha")
+        )
+        let dataBundleB = try Self.makeDataOnlyBundle(
+            dataPath: "\(prefixPath)/b",
+            value: .string("beta")
+        )
+
+        var engine = OPA.Engine(bundles: [
+            "policy": policyBundle,
+            "data_a": dataBundleA,
+            "data_b": dataBundleB,
+        ])
+        let pq = try await engine.prepareForEvaluation(query: "data/" + decisionPath)
+        let result = try await pq.evaluate(input: .object([:]))
+
+        // Reading the prefix should produce an object containing both
+        // siblings' contributions.
+        let expected: AST.RegoValue = .object([
+            "result": .object([
+                "a": .string("alpha"),
+                "b": .string("beta"),
+            ])
+        ])
+        #expect(result == ResultSet([expected]))
+    }
+}

--- a/Tests/RegoTests/TestHelpers.swift
+++ b/Tests/RegoTests/TestHelpers.swift
@@ -1,6 +1,53 @@
+import AST
 import Foundation
+import Rego
 
 func relPath(_ path: String) -> URL {
     let resourcesURL = Bundle.module.resourceURL!
     return resourcesURL.appending(path: path)
+}
+
+public func makeExampleBundle(
+    manifest: OPA.Manifest? = nil,
+    planFiles: [BundleFile]? = nil,
+    regoFiles: [BundleFile]? = nil,
+    data: AST.RegoValue? = nil
+) throws -> OPA.Bundle {
+    let id = UUID().uuidString
+    let manifest = manifest ?? OPA.Manifest(revision: UUID().uuidString, roots: ["/\(id)"])
+    let planFiles =
+        planFiles ?? [
+            Rego.BundleFile(
+                url: URL(string: "/plan.json")!,
+                data: #"""
+                    {
+                    "static":{"strings":[{"value":"result"},{"value":"1"}],"files":[{"value":"bar.rego"}]},
+                    "plans":{"plans":[{"name":"foo/hello","blocks":[{"stmts":[
+                    {"type":"CallStmt","stmt":{"func":"g0.data.foo.hello","args":[{"type":"local","value":0},{"type":"local","value":1}],"result":2,"file":0,"col":0,"row":0}},
+                    {"type":"AssignVarStmt","stmt":{"source":{"type":"local","value":2},"target":3,"file":0,"col":0,"row":0}},
+                    {"type":"MakeObjectStmt","stmt":{"target":4,"file":0,"col":0,"row":0}},
+                    {"type":"ObjectInsertStmt","stmt":{"key":{"type":"string_index","value":0},"value":{"type":"local","value":3},"object":4,"file":0,"col":0,"row":0}},
+                    {"type":"ResultSetAddStmt","stmt":{"value":4,"file":0,"col":0,"row":0}}]}]}]},
+                    "funcs":{"funcs":[{"name":"g0.data.foo.hello","params":[0,1],"return":2,"blocks":[{"stmts":[{"type":"ResetLocalStmt","stmt":{"target":3,"file":0,"col":1,"row":3}},{"type":"MakeNumberRefStmt","stmt":{"Index":1,"target":4,"file":0,"col":1,"row":3}},{"type":"AssignVarOnceStmt","stmt":{"source":{"type":"local","value":4},"target":3,"file":0,"col":1,"row":3}}]},{"stmts":[{"type":"IsDefinedStmt","stmt":{"source":3,"file":0,"col":1,"row":3}},{"type":"AssignVarOnceStmt","stmt":{"source":{"type":"local","value":3},"target":2,"file":0,"col":1,"row":3}}]},{"stmts":[{"type":"ReturnLocalStmt","stmt":{"source":2,"file":0,"col":1,"row":3}}]}],"path":["g0","foo","hello"]}]}
+                    }
+                    """#.data(using: .utf8)!
+            )
+        ]
+    let regoFiles =
+        regoFiles ?? [
+            Rego.BundleFile(
+                url: URL(string: "/\(id)/foo/bar.rego")!,
+                data: "package foo\n\nhello=1".data(using: .utf8)!
+            )
+        ]
+    let data =
+        data ?? [
+            "\(id)": [
+                "foo": [
+                    "bar": 1,
+                    "baz": "qux",
+                ]
+            ]
+        ]
+    return try OPA.Bundle(manifest: manifest, planFiles: planFiles, regoFiles: regoFiles, data: data)
 }


### PR DESCRIPTION
### What code changed, and why?

This PR fixes how the `Engine` merges together data trees from separate bundles. Before, it was possible for two bundles to overwrite each other's data sub-trees. Also, no validation was done at runtime to confirm bundles actually had data contained properly under their roots.

Both issues were fixed by:
 - First validating all bundles during `prepareForEvaluation`.
 - Walking the roots and data tree objects of each bundle, issuing writes to the store for each sub-tree.

We now also have tests that verify this behavior, and that validate policies can refer to data from *different* bundles, which is a common use case. (e.g. shipping user groups/permissions separately from the policy that uses that group data.)

---

Performance Note: This PR dramatically increases the cost of `prepareForEvaluation`, so it might be worth introducing some kind of state that tracks which bundles were validated and so on. That may be challenging to do in a way that allows concurrency and/or `Sendable`-ness of the Engine type. 🤔 

### How to test

 - `make test` should pick up the new test suite automatically.

### Related Resources

