### PR TITLE
Engine: Add `BundleCache` to reduce validation costs at query prep time.

### DIFF
--- a/Sources/Rego/Engine+BundleCache.swift
+++ b/Sources/Rego/Engine+BundleCache.swift
@@ -1,0 +1,169 @@
+import AST
+import Foundation
+
+extension OPA.Engine {
+    /// ``BundleCache`` serves as a store for validated bundles.
+    ///
+    /// This allows the runtime to minimize validation costs when
+    /// preparing queries. Per-bundle ``OPA/Bundle/validate()`` results and
+    /// the cross-bundle overlap check are computed eagerly on insertion and
+    /// cached, so repeated ``prepareForEvaluation(query:)`` calls only pay
+    /// validation cost when the bundle set actually changes.
+    final class BundleCache: @unchecked Sendable {
+        /// Cached state for a single bundle.
+        private struct Entry {
+            let bundle: OPA.Bundle
+            /// `nil` if the bundle passed ``OPA/Bundle/validate()``, otherwise
+            /// the error thrown during validation.
+            let validationError: Error?
+        }
+
+        /// Bundles keyed by name, along with their cached validation result.
+        private var entries: [String: Entry] = [:]
+
+        /// Cached result of the most recent overlap check across `entries`.
+        /// `nil` means the last check succeeded.
+        private var overlapError: Error?
+
+        /// Synchronizes access to the mutable cache state.
+        private let lock = NSLock()
+
+        /// Initializes the cache with a set of bundles, eagerly validating
+        /// all bundles, and running the overlap check.
+        public init(bundles: [String: OPA.Bundle] = [:]) {
+            for (name, bundle) in bundles {
+                entries[name] = Self.makeEntry(bundle: bundle)
+            }
+            recomputeOverlapLocked()
+        }
+
+        /// Copy constructor. No validation is performed, but existing
+        /// validation results are copied over.
+        public init(copying other: BundleCache) {
+            other.lock.lock()
+            defer { other.lock.unlock() }
+            self.entries = other.entries
+            self.overlapError = other.overlapError
+        }
+
+        /// Adds or replaces a single bundle. Validates the bundle and
+        /// recomputes the overlap check. A name collision overwrites the
+        /// previous entry.
+        public func add(name: String, bundle: OPA.Bundle) {
+            lock.lock()
+            defer { lock.unlock() }
+            entries[name] = Self.makeEntry(bundle: bundle)
+            recomputeOverlapLocked()
+        }
+
+        /// Adds or replaces multiple bundles at once. More efficient than
+        /// calling ``add(name:bundle:)`` repeatedly because the overlap check
+        /// only runs once at the end.
+        public func add(bundles: [String: OPA.Bundle]) {
+            guard !bundles.isEmpty else { return }
+            lock.lock()
+            defer { lock.unlock() }
+            for (name, bundle) in bundles {
+                entries[name] = Self.makeEntry(bundle: bundle)
+            }
+            recomputeOverlapLocked()
+        }
+
+        /// Removes a single bundle from the cache. If the cache currently has
+        /// an overlap error, the overlap check is recomputed (since removing
+        /// a bundle may resolve the overlap). Otherwise the overlap check is
+        /// skipped, because removing bundles can only reduce overlap.
+        ///
+        /// - Returns: `true` if a bundle with the given name was removed.
+        @discardableResult
+        public func remove(name: String) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard entries.removeValue(forKey: name) != nil else {
+                return false
+            }
+            if overlapError != nil {
+                recomputeOverlapLocked()
+            }
+            return true
+        }
+
+        /// Removes multiple bundles from the cache. More efficient than
+        /// calling ``remove(name:)`` repeatedly, since the overlap check is
+        /// at most recomputed once at the end (and only if the cache
+        /// previously had an overlap error).
+        ///
+        /// - Returns: The names that were actually removed.
+        @discardableResult
+        public func remove(names: some Sequence<String>) -> Set<String> {
+            lock.lock()
+            defer { lock.unlock() }
+            var removed: Set<String> = []
+            for name in names {
+                if entries.removeValue(forKey: name) != nil {
+                    removed.insert(name)
+                }
+            }
+            if !removed.isEmpty, overlapError != nil {
+                recomputeOverlapLocked()
+            }
+            return removed
+        }
+
+        /// Removes all bundles from the cache and clears the cached overlap
+        /// result (an empty bundle set trivially has no overlap).
+        public func removeAll() {
+            lock.lock()
+            defer { lock.unlock() }
+            entries.removeAll()
+            overlapError = nil
+        }
+
+        /// Returns the cached set of bundles, throwing if either the overlap
+        /// check or any individual bundle validation failed.
+        ///
+        /// Overlap errors are surfaced first, then per-bundle validation
+        /// errors in sorted name order.
+        public func validated() throws -> [String: OPA.Bundle] {
+            let (snapshot, err): ([String: Entry], Error?) = {
+                lock.lock()
+                defer { lock.unlock() }
+                return (entries, overlapError)
+            }()
+            if let err { throw err }
+            for (name, entry) in snapshot.sorted(by: { $0.key < $1.key }) {
+                if let err = entry.validationError {
+                    throw RegoError(
+                        code: .bundleLoadError,
+                        message: "failed to validate bundle \(name)",
+                        cause: err
+                    )
+                }
+            }
+            return snapshot.mapValues { $0.bundle }
+        }
+
+        /// Eagerly runs ``OPA/Bundle/validate()`` and captures any error.
+        private static func makeEntry(bundle: OPA.Bundle) -> Entry {
+            do {
+                try bundle.validate()
+                return Entry(bundle: bundle, validationError: nil)
+            } catch {
+                return Entry(bundle: bundle, validationError: error)
+            }
+        }
+
+        /// Recomputes and caches the overlap check across all current entries.
+        /// Must be called with `lock` held.
+        private func recomputeOverlapLocked() {
+            let bundles = entries.mapValues { $0.bundle }
+            do {
+                try OPA.Bundle.checkBundlesForOverlap(bundleSet: bundles)
+                overlapError = nil
+            } catch {
+                overlapError = error
+            }
+        }
+
+    }
+}

--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -9,7 +9,7 @@ extension OPA {
         private var bundlePaths: [BundlePath]?
 
         // bundles are bundles after loading from disk
-        private var bundles: [String: OPA.Bundle] = [:]
+        private var bundles: BundleCache = BundleCache(bundles: [:])
 
         // directly load IR Policies, mostly useful for testing
         private var policies: [IR.Policy] = []
@@ -59,7 +59,7 @@ extension OPA.Engine {
         capabilities: CapabilitiesInput? = nil,
         customBuiltins: [String: Builtin] = [:]
     ) {
-        self.bundles = bundles
+        self.bundles = BundleCache(bundles: bundles)
         self.capabilities = capabilities
         self.customBuiltins = customBuiltins
     }
@@ -127,6 +127,10 @@ extension OPA.Engine {
     /// and prepares the provided query for evaluation.
     /// Uses default + custom builtins (specified at ``OPA/Engine`` initialization) to validate and evaluate builtin calls.
     ///
+    /// ## Store Behavior
+    /// When this method is called, any data in the store will be overwritten with the current combined
+    /// data tree available from the loaded bundles (including anything from bundles loaded from disk).
+    ///
     /// - Parameters:
     ///   - query: The query to prepare evaluation for.
     /// - Returns: A PreparedQuery that can be used to evaluate the given query.
@@ -148,43 +152,46 @@ extension OPA.Engine {
         )
         let mergedBuiltinRegistry = BuiltinRegistry(builtins: builtins)
 
-        // Load all the bundles from disk
-        // This includes parsing their data trees, etc.
-        var loadedBundles = self.bundles
-        for path in bundlePaths ?? [] {
-            guard loadedBundles[path.name] == nil else {
-                throw RegoError(
-                    code: .bundleNameConflictError,
-                    message: "encountered conflicting bundle names: \(path.name)"
-                )
+        // Bundles supplied via `init(bundles:)` live in `self.bundles` and are
+        // validated once at construction. We never mutate that cache here so
+        // repeated calls reuse its cached validation and overlap results.
+        //
+        // Bundles referenced via `init(bundlePaths:)` are (re)read from disk on
+        // every call and staged on top of a copy of the base cache.
+        var diskLoaded: [String: OPA.Bundle] = [:]
+        if let bundlePaths, !bundlePaths.isEmpty {
+            // Snapshot cached names once for cheap conflict checks below.
+            let cachedNames = Set(try self.bundles.validated().keys)
+
+            for path in bundlePaths {
+                guard !cachedNames.contains(path.name), diskLoaded[path.name] == nil else {
+                    throw RegoError(
+                        code: .bundleNameConflictError,
+                        message: "encountered conflicting bundle names: \(path.name)"
+                    )
+                }
+                do {
+                    diskLoaded[path.name] = try BundleLoader.load(fromFile: path.url)
+                } catch {
+                    throw RegoError(
+                        code: .bundleLoadError,
+                        message: "failed to load bundle \(path.name)",
+                        cause: error
+                    )
+                }
             }
-            var b: OPA.Bundle
-            do {
-                b = try BundleLoader.load(fromFile: path.url)
-            } catch {
-                throw RegoError(
-                    code: .bundleLoadError,
-                    message: "failed to load bundle \(path.name)",
-                    cause: error
-                )
-            }
-            loadedBundles[path.name] = b
         }
 
-        // Verify correctness of this bundle set (no overlapping roots).
-        try OPA.Bundle.checkBundlesForOverlap(bundleSet: loadedBundles)
-
-        // Verify each bundle's data is contained under its roots.
-        for (name, bundle) in loadedBundles.sorted(by: { $0.key < $1.key }) {
-            do {
-                try bundle.validate()
-            } catch {
-                throw RegoError(
-                    code: .bundleLoadError,
-                    message: "failed to validate bundle \(name)",
-                    cause: error
-                )
-            }
+        // Fast path for the common case: no disk bundles -> use the base cache
+        // directly. Slow path: stage disk bundles on top of a copy so we can
+        // run a single validation/overlap check over the combined set.
+        let loadedBundles: [String: OPA.Bundle]
+        if diskLoaded.isEmpty {
+            loadedBundles = try self.bundles.validated()
+        } else {
+            let workingCache = BundleCache(copying: self.bundles)
+            workingCache.add(bundles: diskLoaded)
+            loadedBundles = try workingCache.validated()
         }
 
         // Write each bundle's data into the store at paths corresponding to
@@ -227,9 +234,9 @@ extension OPA.Engine {
 
         let evaluator: IREvaluator
 
-        if self.policies.count > 0 {
+        if !self.policies.isEmpty {
             guard loadedBundles.isEmpty else {
-                throw RegoError.init(code: .invalidArgumentError, message: "Cannot mix direct IR policies with bundles")
+                throw RegoError(code: .invalidArgumentError, message: "Cannot mix direct IR policies with bundles")
             }
 
             evaluator = try IREvaluator(policies: self.policies)


### PR DESCRIPTION
### What code changed, and why?

This PR introduces a `BundleCache` type that the Engine can use to efficiently track loaded bundles and their validation state.

In PR #139, per-bundle `validate()` calls were introduced, which could be expensive to compute on larger bundles, particularly if many queries needed to be prepared.

The `BundleCache` solves this issue by eagerly running the per-bundle and cross-bundle checks whenever the set of loaded bundles changes. This allows `prepareForEvaluation` to avoid redoing validation work that may have happened earlier.

Fixes: #140

### How to test

 - Existing tests provide around 60% coverage of the `BundleCache` implementation (basically just the `remove` method variants are not tested), but I can add additional tests if desired.

### Related Resources

