### PR TITLE
IR: Fix Encodable implementation for Block and Operand.

### DIFF
--- a/Sources/IR/IR.swift
+++ b/Sources/IR/IR.swift
@@ -116,6 +116,13 @@ extension Block: Codable {
         case innerStatement = "stmt"
     }
 
+    // Matches the encoded statement wrapper: {"type": "<name>", "stmt": {...}}.
+    // Used by encode(to:) (decode(from:) still uses PartialStatement + InnerCodingKeys).
+    enum WrapperCodingKeys: String, CodingKey {
+        case type
+        case innerStatement = "stmt"
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         var iter = try container.nestedUnkeyedContainer(forKey: .statements)
@@ -243,8 +250,21 @@ extension Block: Codable {
     }
 
     public func encode(to encoder: any Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode("block(stmt_count=\(statements.count))")
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var stmts = container.nestedUnkeyedContainer(forKey: .statements)
+        for statement in self.statements {
+            var wrapper = stmts.nestedContainer(keyedBy: WrapperCodingKeys.self)
+            guard let typeName = statement.typeName else {
+                throw EncodingError.invalidValue(
+                    statement,
+                    EncodingError.Context(
+                        codingPath: wrapper.codingPath,
+                        debugDescription: "Cannot encode Statement.unknown"
+                    ))
+            }
+            try wrapper.encode(typeName, forKey: .type)
+            try statement.encodeInner(to: wrapper.superEncoder(forKey: .innerStatement))
+        }
     }
 }
 
@@ -577,6 +597,113 @@ extension Statement {
     }
 }
 
+extension Statement {
+    /// Stringified type name for this statement, mirroring `PartialStatement.KnownStatements`.
+    /// Returns `nil` for `.unknown`, which has no serialized representation.
+    var typeName: String? {
+        switch self {
+        case .arrayAppendStmt: return "ArrayAppendStmt"
+        case .assignIntStmt: return "AssignIntStmt"
+        case .assignVarOnceStmt: return "AssignVarOnceStmt"
+        case .assignVarStmt: return "AssignVarStmt"
+        case .blockStmt: return "BlockStmt"
+        case .breakStmt: return "BreakStmt"
+        case .callDynamicStmt: return "CallDynamicStmt"
+        case .callStmt: return "CallStmt"
+        case .dotStmt: return "DotStmt"
+        case .equalStmt: return "EqualStmt"
+        case .isArrayStmt: return "IsArrayStmt"
+        case .isDefinedStmt: return "IsDefinedStmt"
+        case .isObjectStmt: return "IsObjectStmt"
+        case .isSetStmt: return "IsSetStmt"
+        case .isUndefinedStmt: return "IsUndefinedStmt"
+        case .lenStmt: return "LenStmt"
+        case .makeArrayStmt: return "MakeArrayStmt"
+        case .makeNullStmt: return "MakeNullStmt"
+        case .makeNumberIntStmt: return "MakeNumberIntStmt"
+        case .makeNumberRefStmt: return "MakeNumberRefStmt"
+        case .makeObjectStmt: return "MakeObjectStmt"
+        case .makeSetStmt: return "MakeSetStmt"
+        case .nopStmt: return "NopStmt"
+        case .notEqualStmt: return "NotEqualStmt"
+        case .notStmt: return "NotStmt"
+        case .objectInsertOnceStmt: return "ObjectInsertOnceStmt"
+        case .objectInsertStmt: return "ObjectInsertStmt"
+        case .objectMergeStmt: return "ObjectMergeStmt"
+        case .resetLocalStmt: return "ResetLocalStmt"
+        case .resultSetAddStmt: return "ResultSetAddStmt"
+        case .returnLocalStmt: return "ReturnLocalStmt"
+        case .scanStmt: return "ScanStmt"
+        case .setAddStmt: return "SetAddStmt"
+        case .withStmt: return "WithStmt"
+        case .unknown: return nil
+        }
+    }
+
+    fileprivate enum LocationCodingKeys: String, CodingKey {
+        case row
+        case col
+        case file
+    }
+
+    // Encodes the body of a statement's `stmt` object: the concrete statement's own
+    // fields plus the inline `row`, `col`, `file` location fields the OPA IR expects.
+    // The two writes share the encoder's top-level keyed container, matching the
+    // decoder — which pulls location via `PartialStatement` and the other fields via
+    // the concrete type.
+    func encodeInner(to encoder: Encoder) throws {
+        switch self {
+        case .arrayAppendStmt(let s): try s.encode(to: encoder)
+        case .assignIntStmt(let s): try s.encode(to: encoder)
+        case .assignVarOnceStmt(let s): try s.encode(to: encoder)
+        case .assignVarStmt(let s): try s.encode(to: encoder)
+        case .blockStmt(let s): try s.encode(to: encoder)
+        case .breakStmt(let s): try s.encode(to: encoder)
+        case .callDynamicStmt(let s): try s.encode(to: encoder)
+        case .callStmt(let s): try s.encode(to: encoder)
+        case .dotStmt(let s): try s.encode(to: encoder)
+        case .equalStmt(let s): try s.encode(to: encoder)
+        case .isArrayStmt(let s): try s.encode(to: encoder)
+        case .isDefinedStmt(let s): try s.encode(to: encoder)
+        case .isObjectStmt(let s): try s.encode(to: encoder)
+        case .isSetStmt(let s): try s.encode(to: encoder)
+        case .isUndefinedStmt(let s): try s.encode(to: encoder)
+        case .lenStmt(let s): try s.encode(to: encoder)
+        case .makeArrayStmt(let s): try s.encode(to: encoder)
+        case .makeNullStmt(let s): try s.encode(to: encoder)
+        case .makeNumberIntStmt(let s): try s.encode(to: encoder)
+        case .makeNumberRefStmt(let s): try s.encode(to: encoder)
+        case .makeObjectStmt(let s): try s.encode(to: encoder)
+        case .makeSetStmt(let s): try s.encode(to: encoder)
+        case .nopStmt(let s): try s.encode(to: encoder)
+        case .notEqualStmt(let s): try s.encode(to: encoder)
+        case .notStmt(let s): try s.encode(to: encoder)
+        case .objectInsertOnceStmt(let s): try s.encode(to: encoder)
+        case .objectInsertStmt(let s): try s.encode(to: encoder)
+        case .objectMergeStmt(let s): try s.encode(to: encoder)
+        case .resetLocalStmt(let s): try s.encode(to: encoder)
+        case .resultSetAddStmt(let s): try s.encode(to: encoder)
+        case .returnLocalStmt(let s): try s.encode(to: encoder)
+        case .scanStmt(let s): try s.encode(to: encoder)
+        case .setAddStmt(let s): try s.encode(to: encoder)
+        case .withStmt(let s): try s.encode(to: encoder)
+        case .unknown:
+            throw EncodingError.invalidValue(
+                self,
+                EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Cannot encode Statement.unknown"
+                ))
+        }
+
+        let loc = self.location
+        var container = encoder.container(keyedBy: LocationCodingKeys.self)
+        try container.encode(loc.row, forKey: .row)
+        try container.encode(loc.col, forKey: .col)
+        try container.encode(loc.file, forKey: .file)
+    }
+}
+
 // AnyInnerStatement represents the generic stmt field, which should always contain location fields.
 public struct AnyInnerStatement: Codable, Hashable {
     public var row: Int = 0
@@ -685,6 +812,22 @@ extension Operand: Codable {
         case .stringIndex:
             let v = try container.decode(Int.self, forKey: .value)
             self.value = Value.stringIndex(v)
+        }
+    }
+
+    // The synthesized encoder for `Value` (an enum with associated values) would emit
+    // something like {"localIndex": {"_0": 7}}, which does not roundtrip through our
+    // custom decoder. Encode `value` as a bare Int/Bool alongside the `type` tag.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.type, forKey: .type)
+        switch self.value {
+        case .localIndex(let v):
+            try container.encode(v, forKey: .value)
+        case .bool(let v):
+            try container.encode(v, forKey: .value)
+        case .stringIndex(let v):
+            try container.encode(v, forKey: .value)
         }
     }
 }

--- a/Sources/IR/Statements.swift
+++ b/Sources/IR/Statements.swift
@@ -325,6 +325,13 @@ public struct NopStatement: Sendable, Codable, Hashable {
     // and do nothing.
     public init(from decoder: Decoder) throws {
     }
+
+    public init() {}
+
+    // Mirror the decoder: emit no fields. Block's encoder writes row/col/file into
+    // the lazily created, keyed container on this encoder afterward.
+    public func encode(to encoder: Encoder) throws {
+    }
 }
 
 public struct NotStatement: Sendable, Codable, Hashable {

--- a/Tests/IRTests/GoldenIRTests.swift
+++ b/Tests/IRTests/GoldenIRTests.swift
@@ -24,3 +24,17 @@ func testParsingGolden(input: TestURL) async throws {
     let data = try Data(contentsOf: input.url)
     let _ = try JSONDecoder().decode(Policy.self, from: data)
 }
+
+// Round-trip each golden fixture through the full serdes flow:
+// JSON -> Policy -> JSON -> Policy, asserting that the re-decoded
+// policy matches the first one. The JSON bytes themselves are not
+// required to match (key order, whitespace, and optional/default
+// fields can differ), but the model must survive the trip.
+@Test("testRoundtripGolden", arguments: goldenFiles())
+func testRoundtripGolden(input: TestURL) async throws {
+    let data = try Data(contentsOf: input.url)
+    let first = try JSONDecoder().decode(Policy.self, from: data)
+    let encoded = try JSONEncoder().encode(first)
+    let second = try JSONDecoder().decode(Policy.self, from: encoded)
+    #expect(first == second)
+}

--- a/Tests/IRTests/IREncodeTests.swift
+++ b/Tests/IRTests/IREncodeTests.swift
@@ -1,0 +1,194 @@
+import AST
+import Foundation
+import Testing
+
+@testable import IR
+
+// EncodeTests verify that the IR types produce JSON in a format that
+// our decoder can understand.
+
+@Test("roundtrip Operand cases")
+func roundtripOperand() throws {
+    let cases: [Operand] = [
+        Operand(type: .local, value: .localIndex(0)),
+        Operand(type: .local, value: .localIndex(42)),
+        Operand(type: .bool, value: .bool(true)),
+        Operand(type: .bool, value: .bool(false)),
+        Operand(type: .stringIndex, value: .stringIndex(17)),
+    ]
+    for op in cases {
+        let data = try JSONEncoder().encode(op)
+        let decoded = try JSONDecoder().decode(Operand.self, from: data)
+        #expect(decoded == op)
+    }
+}
+
+@Test("encoded Operand matches expected format")
+func encodedOperandShape() throws {
+    let op = Operand(type: .local, value: .localIndex(7))
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(op)
+    let asString = String(data: data, encoding: .utf8)
+    #expect(asString == #"{"type":"local","value":7}"#)
+
+    let strOp = Operand(type: .stringIndex, value: .stringIndex(3))
+    let strData = try encoder.encode(strOp)
+    #expect(String(data: strData, encoding: .utf8) == #"{"type":"string_index","value":3}"#)
+
+    let boolOp = Operand(type: .bool, value: .bool(true))
+    let boolData = try encoder.encode(boolOp)
+    #expect(String(data: boolData, encoding: .utf8) == #"{"type":"bool","value":true}"#)
+}
+
+@Test("roundtrip Block with representative statements")
+func roundtripBlock() throws {
+    let block = Block(
+        statements: [
+            .callStmt(
+                CallStatement(
+                    location: Location(row: 49, col: 10, file: 50),
+                    callFunc: "plus",
+                    args: [
+                        Operand(type: .local, value: .localIndex(6)),
+                        Operand(type: .local, value: .localIndex(7)),
+                    ],
+                    result: Local(8)
+                )),
+            .assignVarStmt(
+                AssignVarStatement(
+                    location: Location(row: 1, col: 2, file: 3),
+                    source: Operand(type: .local, value: .localIndex(2)),
+                    target: Local(3)
+                )),
+            .makeObjectStmt(
+                MakeObjectStatement(
+                    location: Location(row: 4, col: 5, file: 6),
+                    target: Local(4)
+                )),
+            .objectInsertStmt(
+                ObjectInsertStatement(
+                    location: Location(row: 7, col: 8, file: 9),
+                    key: Operand(type: .stringIndex, value: .stringIndex(0)),
+                    value: Operand(type: .local, value: .localIndex(3)),
+                    object: Local(4)
+                )),
+            .resultSetAddStmt(ResultSetAddStatement(value: Local(4))),
+            // nop exercises the empty-body statement case
+            .nopStmt(NopStatement()),
+        ]
+    )
+
+    let encoded = try JSONEncoder().encode(block)
+    let decoded = try JSONDecoder().decode(Block.self, from: encoded)
+    #expect(decoded == block)
+}
+
+@Test("roundtrip Block with nested blocks (not/with/scan)")
+func roundtripBlockNested() throws {
+    let inner = Block(
+        statements: [
+            .assignVarOnceStmt(
+                AssignVarOnceStatement(
+                    location: Location(row: 30, col: 1, file: 0),
+                    source: Operand(type: .local, value: .localIndex(19)),
+                    target: Local(3)
+                ))
+        ]
+    )
+
+    let block = Block(
+        statements: [
+            .withStmt(
+                WithStatement(
+                    location: Location(row: 31, col: 9, file: 0),
+                    local: Local(0),
+                    path: [1, 2],
+                    value: Operand(type: .local, value: .localIndex(8)),
+                    block: inner
+                )),
+            .notStmt(
+                NotStatement(
+                    location: Location(row: 40, col: 2, file: 0),
+                    block: inner
+                )),
+            .scanStmt(
+                ScanStatement(
+                    source: Local(1),
+                    key: Local(2),
+                    value: Local(3),
+                    block: inner
+                )),
+        ]
+    )
+
+    let encoded = try JSONEncoder().encode(block)
+    let decoded = try JSONDecoder().decode(Block.self, from: encoded)
+    #expect(decoded == block)
+}
+
+@Test("Statement.unknown fails to encode")
+func encodeUnknownFails() {
+    let block = Block(statements: [.unknown(Location(row: 0, col: 0, file: 0))])
+    #expect(throws: EncodingError.self) {
+        _ = try JSONEncoder().encode(block)
+    }
+}
+
+@Test("roundtrip full Policy with plan and funcs")
+func roundtripPolicy() throws {
+    let policy = Policy(
+        staticData: Static(
+            strings: [
+                ConstString(value: "result"),
+                ConstString(value: "message"),
+            ],
+            files: [ConstString(value: "example.rego")]
+        ),
+        plans: Plans(
+            plans: [
+                Plan(
+                    name: "policy/hello",
+                    blocks: [
+                        Block(statements: [
+                            .callStmt(
+                                CallStatement(
+                                    location: Location(row: 0, col: 8, file: 9),
+                                    callFunc: "g0.data.policy.hello",
+                                    args: [
+                                        Operand(type: .local, value: .localIndex(0)),
+                                        Operand(type: .local, value: .localIndex(1)),
+                                    ],
+                                    result: Local(2)
+                                )),
+                            .resultSetAddStmt(ResultSetAddStatement(value: Local(4))),
+                        ])
+                    ]
+                )
+            ]
+        ),
+        funcs: Funcs(
+            funcs: [
+                Func(
+                    name: "g0.data.policy.hello",
+                    path: ["g0", "policy", "hello"],
+                    params: [Local(0), Local(1)],
+                    returnVar: Local(2),
+                    blocks: [
+                        Block(statements: [
+                            .returnLocalStmt(
+                                ReturnLocalStatement(
+                                    location: Location(row: 5, col: 9, file: 0),
+                                    source: Local(2)
+                                ))
+                        ])
+                    ]
+                )
+            ]
+        )
+    )
+
+    let encoded = try JSONEncoder().encode(policy)
+    let decoded = try JSONDecoder().decode(Policy.self, from: encoded)
+    #expect(decoded == policy)
+}


### PR DESCRIPTION
### What code changed, and why?

This commit fills in the `Encodable` implementation for the `IR.Block` type, and for `IR.Operand`. It is now possible to round-trip the IR policy JSON through the `IR` module types, and back again to JSON.

Before these changes, Blocks only printed a debug string showing the number of statements in the block, instead of the serialized IR statements. This broke JSON encoding.

The Operand type had issues from being an enum type. It now has a custom encoding implementation, ensuring the three operand types render correctly in JSON.

### How to test

 - New tests are automatically picked up by `make test`, as part of the IR "Golden" and encoding test suites.

### Related Resources

