### PR TITLE
Engine: Improve plan validation and store behavior. Add remove op for store.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Improved plan validation in Engine
+
+The `Engine` now validates that plans are contained under the roots of their parent bundles.
+We also now support loading user-provided raw IR policies alongside bundles.
+The improved validation ensures that plan names are unique across all sources, and that user-supplied plans don't conflict with plans or paths under the roots of any bundles.
+
+The new validation is done at `prepareForEvaluation` time, and will throw descriptive errors if anything is amiss.
+
+### Improved store behavior
+
+In previous versions, the `Engine` would wipe out the store on each call to `prepareForEvaluation`, and would write only bundle contents back into the store.
+This was acceptable for bundle-centric workflows, but limited many other use cases OPA supports.
+
+We now modify the store at `prepareForEvaluation` in a manner much closer to OPA's bundle activation flow.
+First, all old bundle roots are erased.
+Then, all new/retained bundle roots are written to, ensuring the live set of bundles will always have consistent state written to the store.
+Any user-modified locations in the store that are outside of those paths will be unmodified.
+
+### `OPA.Store` protocol gains `remove(at:)`
+
+The `OPA.Store` protocol now requires `mutating func remove(at: StoreKeyPath) async throws`.
+This method removes the value at the given path, including the leaf key from its parent object.
+A non-existent path is a no-op.
+Removing the root path resets the store to an empty object.
+
+This new API moves us closer to supporting the range of store functionality that OPA provides.
+
+Authored by @philipaconrad
+
 ## 0.0.5
 
 This release contains bugfixes for multi-bundle use cases, performance improvements, and new builtin implementations!

--- a/Sources/AST/RegoValue+PatchMerge.swift
+++ b/Sources/AST/RegoValue+PatchMerge.swift
@@ -38,6 +38,77 @@ extension RegoValue {
             return .object(o)
         }
     }
+
+    // removing returns a new RegoValue with the value at the given path removed.
+    // If the path does not exist, the value is returned unchanged. For an object
+    // node the leaf key is removed from its parent. For an array node the element
+    // at the integer-valued segment is removed and the array is compacted.
+    // Ancestors are preserved even if they become empty as a result. A segment
+    // that does not address the current node (a non-integer index into an array,
+    // an out-of-bounds index, a missing object key, or any segment into a scalar
+    // or set) is a no-op. An empty path resets the value to an empty object,
+    // matching the "reset the store" semantics callers expect at the root.
+    package func removing(at path: [String]) -> RegoValue {
+        // An empty path addresses the root itself. Removing the root resets the
+        // value to an empty object, matching the "reset the store" semantics
+        // callers expect. This only makes sense at the root, so it is handled
+        // here at the entry point rather than in the recursive core, which only
+        // ever sees non-empty paths.
+        guard !path.isEmpty else {
+            return .object([:])
+        }
+        return removing(at: path[...])
+    }
+
+    // This variant of ``removing`` works on an ArraySlice, and is the
+    // recursive core for removal operations. It assumes a non-empty path: the
+    // recursion removes a leaf directly once `restOfPath` is empty and only
+    // recurses on a non-empty remainder, so the empty-path case never reaches
+    // here. The root-reset case is handled by the entry point above.
+    package func removing(at path: ArraySlice<String>) -> RegoValue {
+        guard let i = path.indices.first else {
+            // Defensive no-op: a non-root empty path does not address anything.
+            return self
+        }
+        let segment = path[i]
+        let restOfPath = path[i.advanced(by: 1)...]
+
+        switch self {
+        case .object(var o):
+            let k = RegoValue.string(segment)
+            guard let child = o[k] else {
+                return self
+            }
+            if restOfPath.isEmpty {
+                // Leaf: remove the key from the parent.
+                o.removeValue(forKey: k)
+                return .object(o)
+            }
+            // Recurse into the child; reattach the child structure, post-deletion.
+            o[k] = child.removing(at: restOfPath)
+            return .object(o)
+
+        case .array(var a):
+            // Arrays are addressed by a non-negative integer index. Anything
+            // else (non-integer or out-of-bounds) does not address an element,
+            // so it is a no-op.
+            guard let idx = Int(segment), idx >= 0, idx < a.count else {
+                return self
+            }
+            if restOfPath.isEmpty {
+                // Leaf: remove the element, compacting the array.
+                a.remove(at: idx)
+                return .array(a)
+            }
+            // Recurse into the element; reattach post-deletion.
+            a[idx] = a[idx].removing(at: restOfPath)
+            return .array(a)
+
+        default:
+            // Scalars and sets carry no addressable path: no-op.
+            return self
+        }
+    }
 }
 
 // Support for merging a .object RegoValue with another

--- a/Sources/Rego/Bundle.swift
+++ b/Sources/Rego/Bundle.swift
@@ -182,6 +182,31 @@ extension OPA.Bundle {
         }
     }
 
+    /// Returns true if `path` falls under at least one of the declared `roots`.
+    ///
+    /// Both `roots` and `path` are slash-separated. An empty root (`""` or
+    /// `"/"`) matches everything.
+    ///
+    /// Implementation: paths are canonicalized to `"/<trimmed>/"` form (or
+    /// `"/"` for the empty roots).
+    public static func rootPathsContain(_ roots: [String], _ path: String) -> Bool {
+        // Trim slashes, then add leading/trailing "/" so byte-prefix comparison
+        // matches segment-prefix semantics. e.g. canonical "/a/b/" is a prefix
+        // of "/a/b/c/" but not of "/a/bc/".
+        let canonicalPath: String = {
+            let trimmed = path.trimmingCharacters(in: ["/"])
+            return trimmed.isEmpty ? "/" : "/" + trimmed + "/"
+        }()
+        for raw in roots {
+            let trimmed = raw.trimmingCharacters(in: ["/"])
+            let canonicalRoot = trimmed.isEmpty ? "/" : "/" + trimmed + "/"
+            if canonicalPath.hasPrefix(canonicalRoot) {
+                return true
+            }
+        }
+        return false
+    }
+
     /// checkBundlesForOverlap verifies whether a set of bundles is valid
     /// together, in that there are no overlaps of their reserved roots
     /// space within the logical data tree.

--- a/Sources/Rego/Engine+Prepare.swift
+++ b/Sources/Rego/Engine+Prepare.swift
@@ -100,4 +100,49 @@ extension OPA.Engine {
             }
         }
     }
+
+    /// Rejects user-supplied IR policies whose plan names fall under any
+    /// bundle's declared roots.
+    ///
+    /// ``IREvaluator`` ensures a bundle's plans must lie under its roots,
+    /// and that plan-names are globally unique. Roots overlap between
+    /// bundles is prevented by the bundle cache. This check prevents
+    /// user IR policies from having plan names that overlap with any
+    /// existing bundle roots.
+    ///
+    /// - Throws: `RegoError.planNameConflictError` listing every offending
+    ///   user plan and the bundles whose roots claim it.
+    static func checkUserPoliciesAgainstBundleRoots(
+        userPolicies: [IR.Policy],
+        bundles: [String: OPA.Bundle]
+    ) throws {
+        // Collect (bundleName, root) pairs.
+        let bundleRoots: [(name: String, roots: [String])] =
+            bundles
+            .sorted(by: { $0.key < $1.key })
+            .map { ($0.key, $0.value.manifest.roots) }
+
+        // planName -> sorted list of bundles whose roots claim it.
+        var conflicts: [String: [String]] = [:]
+        for (i, policy) in userPolicies.enumerated() {
+            for plan in policy.plans?.plans ?? [] {
+                for (bundleName, roots) in bundleRoots
+                where OPA.Bundle.rootPathsContain(roots, plan.name) {
+                    let key = "user:#\(i) '\(plan.name)'"
+                    conflicts[key, default: []].append("bundle:\(bundleName)")
+                }
+            }
+        }
+
+        guard !conflicts.isEmpty else { return }
+
+        let parts = conflicts.keys.sorted().map { key in
+            let owners = conflicts[key]!.sorted()
+            return "\(key) falls under roots of [\(owners.joined(separator: ", "))]"
+        }
+        throw RegoError(
+            code: .planNameConflictError,
+            message: "user IR policy plan names conflict with bundle roots: \(parts.joined(separator: "; "))"
+        )
+    }
 }

--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -22,6 +22,13 @@ extension OPA {
 
         // Custom builtins that are specified along the default builtins
         private var customBuiltins: [String: Builtin] = [:]
+
+        // Bundle-owned `/data` subtrees written by the most recent
+        // `prepareForEvaluation(query:)` call. The next prepare call uses
+        // this set (along with the new prepare's roots) to decide which
+        // subtrees to erase before writing fresh bundle data into the store.
+        // User data outside this set survives across prepare calls.
+        private var lastWrittenBundleRoots: Set<StoreKeyPath> = []
     }
 }
 
@@ -128,8 +135,19 @@ extension OPA.Engine {
     /// Uses default + custom builtins (specified at ``OPA/Engine`` initialization) to validate and evaluate builtin calls.
     ///
     /// ## Store Behavior
-    /// When this method is called, any data in the store will be overwritten with the current combined
-    /// data tree available from the loaded bundles (including anything from bundles loaded from disk).
+    /// Bundle-owned `/data` subtrees are refreshed on every call: the union
+    /// of the previously written bundle roots + currently declared bundle roots
+    /// is erased before fresh bundle data is written. Anything outside that
+    /// union is preserved across calls. user-supplied data sitting at paths
+    /// outside by any bundle roots survives a prepare call.
+    ///
+    /// ## Bundles + raw IR policies
+    /// If the engine was constructed with a mix of bundles and raw user IR
+    /// policies (via ``init(policies:store:capabilities:customBuiltins:)``
+    /// alongside ``init(bundles:capabilities:customBuiltins:)``-style
+    /// inputs), the union is composed at preparation time. Plan names must
+    /// be unique across the entire union, and bundle plan names must lie
+    /// under one of their bundle's declared roots.
     ///
     /// - Parameters:
     ///   - query: The query to prepare evaluation for.
@@ -194,6 +212,41 @@ extension OPA.Engine {
             loadedBundles = try workingCache.validated()
         }
 
+        // Compute the set of `/data/...` subtrees the current bundle set
+        // claims. We erase only the union of the previously written roots +
+        // newly declared roots, which leaves user data outside both sets
+        // untouched across prepare calls.
+        var newRoots: Set<StoreKeyPath> = []
+        for (_, bundle) in loadedBundles {
+            for root in bundle.manifest.roots {
+                let segments = root.split(separator: "/").map(String.init)
+                newRoots.insert(StoreKeyPath(["data"] + segments))
+            }
+        }
+
+        // Erase old + new bundle-owned subtrees in lexicographic order so an
+        // ancestor is removed before any of its descendants.
+        // A missing path is not an error here — the subtree simply wasn't
+        // present (e.g. first prepare on a fresh store), so we skip it.
+        // The recovery block below re-establishes the `data` root as an
+        // empty object whenever a removal leaves it absent.
+        let toErase = lastWrittenBundleRoots.union(newRoots)
+        for path in toErase.sorted(by: { $0.segments.lexicographicallyPrecedes($1.segments) }) {
+            do {
+                try await store.remove(at: path)
+            } catch let err as RegoError where err.code == .storePathNotFound {
+                // Already absent — nothing to erase.
+            }
+        }
+
+        // Ensure the root `data` node exists; removal of the whole `data`
+        // subtree (e.g. a bundle with root "") leaves it absent.
+        do {
+            _ = try await store.read(from: StoreKeyPath(["data"]))
+        } catch {
+            try await store.write(to: StoreKeyPath(["data"]), value: .object([:]))
+        }
+
         // Write each bundle's data into the store at paths corresponding to
         // the bundle's declared roots. `checkBundlesForOverlap` guarantees
         // these root paths are disjoint across bundles, so the per-root
@@ -203,7 +256,6 @@ extension OPA.Engine {
         // A bundle with no data under one of its roots simply writes nothing
         // for that root (e.g. a policy-only bundle whose roots describe
         // decision paths rather than data paths).
-        try await store.write(to: StoreKeyPath(["data"]), value: .object([:]))
         for (_, bundle) in loadedBundles.sorted(by: { $0.key < $1.key }) {
             let roots = bundle.manifest.roots
             for root in roots.sorted() {
@@ -232,17 +284,23 @@ extension OPA.Engine {
             }
         }
 
-        let evaluator: IREvaluator
+        // Remember what we wrote so the next prepare knows what to erase.
+        self.lastWrittenBundleRoots = newRoots
 
-        if !self.policies.isEmpty {
-            guard loadedBundles.isEmpty else {
-                throw RegoError(code: .invalidArgumentError, message: "Cannot mix direct IR policies with bundles")
-            }
-
-            evaluator = try IREvaluator(policies: self.policies)
-        } else {
-            evaluator = try IREvaluator(bundles: loadedBundles)
+        // User-supplied IR policies share the plan-name namespace with
+        // bundles. The IREvaluator already enforces global plan-name
+        // uniqueness. Here we also reject user plans whose names fall
+        // under any bundle's declared roots, because that subtree is
+        // owned by the bundle even if the bundle itself does not currently
+        // define a plan at that exact name.
+        if !self.policies.isEmpty && !loadedBundles.isEmpty {
+            try Self.checkUserPoliciesAgainstBundleRoots(
+                userPolicies: self.policies,
+                bundles: loadedBundles
+            )
         }
+
+        let evaluator = try IREvaluator(bundles: loadedBundles, userPolicies: self.policies)
 
         // TODO: Future improvement - validate local allocation assumptions (see Locals.swift)
         // Could add validation to check:

--- a/Sources/Rego/Error.swift
+++ b/Sources/Rego/Error.swift
@@ -16,6 +16,8 @@ public struct RegoError: Sendable, Swift.Error {
             case bundleRootConflictError
             case bundleUnpreparedError
             case invalidArgumentError
+            case planEscapedBundleRoots
+            case planNameConflictError
 
             // Evaluation errors
             case assignOnceError
@@ -57,6 +59,8 @@ public struct RegoError: Sendable, Swift.Error {
         public static let bundleUnpreparedError = Code(.bundleUnpreparedError)
         public static let internalError = Code(.internalError)
         public static let invalidArgumentError = Code(.invalidArgumentError)
+        public static let planEscapedBundleRoots = Code(.planEscapedBundleRoots)
+        public static let planNameConflictError = Code(.planNameConflictError)
 
         // Evaluation errors
         public static let assignOnceError = Code(.assignOnceError)

--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -6,14 +6,64 @@ import IR
 internal struct IREvaluator {
     let policies: [Bytecode.Policy]
 
-    init(bundles: [String: OPA.Bundle]) throws {
-        var policies: [Bytecode.Policy] = []
-        for (bundleName, bundle) in bundles {
+    /// Lookup table from a plan's entrypoint name (e.g. "foo/bar") to the
+    /// (policy index, plan index) within `policies`. Built at construction
+    /// time and guaranteed to be unique by ``init(bundles:userPolicies:)``.
+    private let planIndex: [String: (policyIdx: Int, planIdx: Int)]
+
+    /// Identifies which source claimed a given plan name during construction.
+    /// Used only for plan-name uniqueness bookkeeping; instances are not
+    /// compared and only stringified on the error path.
+    private enum PlanOwner: Sendable {
+        case bundle(String)
+        case user(Int)
+
+        var displayString: String {
+            switch self {
+            case .bundle(let name): return "bundle:\(name)"
+            case .user(let i): return "user:#\(i)"
+            }
+        }
+    }
+
+    /// Constructs an `IREvaluator` from the union of bundle-supplied IR plans
+    /// and user-supplied raw IR policies.
+    ///
+    /// We validate two properties at construction time:
+    ///
+    /// - Every plan name within a bundle must lie under one of *that bundle's*
+    ///   declared roots. User policies are not constrained to any roots.
+    /// - Plan names must be unique across the entire union. A duplicate name
+    ///   fails with `planNameConflictError`.
+    init(bundles: [String: OPA.Bundle], userPolicies: [IR.Policy] = []) throws {
+        var compiled: [Bytecode.Policy] = []
+        // Plan-name origin tracking. The common case is "each plan name has
+        // exactly one owner". We keep a flat first-claim map for that case and
+        // only spill into `conflicts` when a second source claims the same
+        // name.
+        var firstOwner: [String: PlanOwner] = [:]
+        var conflicts: [String: [PlanOwner]] = [:]
+
+        func recordOwner(planName: String, owner: PlanOwner) {
+            guard let prior = firstOwner[planName] else {
+                firstOwner[planName] = owner
+                return
+            }
+            // If there's more than one claim, promote to a multi-owner conflict entry.
+            if conflicts[planName] == nil {
+                conflicts[planName] = [prior, owner]
+            } else {
+                conflicts[planName]!.append(owner)
+            }
+        }
+
+        for (bundleName, bundle) in bundles.sorted(by: { $0.key < $1.key }) {
             for planFile in bundle.planFiles {
+                let parsed: IR.Policy
                 do {
-                    var parsed = try IR.Policy(jsonData: planFile.data)
-                    try parsed.prepareForExecution()
-                    policies.append(try Converter.convert(parsed))
+                    var p = try IR.Policy(jsonData: planFile.data)
+                    try p.prepareForExecution()
+                    parsed = p
                 } catch {
                     throw RegoError(
                         code: .bundleInitializationError,
@@ -24,35 +74,103 @@ internal struct IREvaluator {
                         cause: error
                     )
                 }
+
+                // Per bundle "plan contained under roots?" check.
+                for plan in parsed.plans?.plans ?? [] {
+                    guard OPA.Bundle.rootPathsContain(bundle.manifest.roots, plan.name) else {
+                        throw RegoError(
+                            code: .planEscapedBundleRoots,
+                            message:
+                                "bundle '\(bundleName)' roots \(bundle.manifest.roots) "
+                                + "do not permit plan '\(plan.name)'"
+                        )
+                    }
+                    recordOwner(planName: plan.name, owner: .bundle(bundleName))
+                }
+
+                let bytecodePolicy: Bytecode.Policy
+                do {
+                    bytecodePolicy = try Converter.convert(parsed)
+                } catch {
+                    throw RegoError(
+                        code: .bundleInitializationError,
+                        message: """
+                            initialization failed for bundle \(bundleName), \
+                            conversion failed in file: \(planFile.url)
+                            """,
+                        cause: error
+                    )
+                }
+                compiled.append(bytecodePolicy)
             }
         }
-        guard !policies.isEmpty else {
+
+        // User policies don't have or need roots, but their plan names
+        // share the namespace and must remain unique against everything else.
+        for (i, raw) in userPolicies.enumerated() {
+            var p = raw
+            try p.prepareForExecution()
+            for plan in p.plans?.plans ?? [] {
+                recordOwner(planName: plan.name, owner: .user(i))
+            }
+            compiled.append(try Converter.convert(p))
+        }
+
+        // Ensure all plan names (raw user policies + bundle policies) are unique.
+        if !conflicts.isEmpty {
+            // Stable, sorted message so callers can match on it. Stringify
+            // owners only here, on the failure path.
+            let parts = conflicts.keys.sorted().map { name in
+                let owners = conflicts[name]!.map { $0.displayString }.sorted()
+                return "'\(name)' defined in [\(owners.joined(separator: ", "))]"
+            }
+            throw RegoError(
+                code: .planNameConflictError,
+                message: "plan name conflicts across sources: \(parts.joined(separator: "; "))"
+            )
+        }
+
+        // We allow cases with zero plans here when raw IR policies were supplied
+        // (some test fixtures provide policies whose only contribution is
+        // funcs). Bundles, on the other hand, must contribute at least one
+        // plan.
+        guard !compiled.isEmpty else {
             throw RegoError(code: .noPlansFoundError, message: "no IR plans were found in any of the provided bundles")
         }
-        self.policies = policies
+
+        // Build the plan name lookup index.
+        var index: [String: (policyIdx: Int, planIdx: Int)] = [:]
+        for (pi, policy) in compiled.enumerated() {
+            for (li, plan) in policy.plans.enumerated() {
+                // We're guaranteed unique keys here, thanks to the earlier conflicts check.
+                index[plan.name] = (pi, li)
+            }
+        }
+
+        self.policies = compiled
+        self.planIndex = index
     }
 
-    // Initialize directly with parsed policies - useful for testing
+    /// Initialize from bundles only. Provided for backwards compatibility.
+    init(bundles: [String: OPA.Bundle]) throws {
+        try self.init(bundles: bundles, userPolicies: [])
+    }
+
+    /// Initialize directly with parsed user policies.
+    /// Intended mainly for testing, and provided for backwards compatibility.
     init(policies: [IR.Policy]) throws {
-        self.policies = try policies.map {
-            var p = $0
-            try p.prepareForExecution()
-            return try Converter.convert(p)
-        }
+        try self.init(bundles: [:], userPolicies: policies)
     }
 }
 
 extension IREvaluator: Evaluator {
     func evaluate(withContext ctx: EvaluationContext) async throws -> ResultSet {
-        // TODO: We're assuming that queries are only ever defined in a single policy... that _should_ hold true.. but who's checkin?
         let entrypoint = try queryToEntryPoint(ctx.query)
-        for policy in policies {
-            if let planIndex = policy.plans.firstIndex(where: { $0.name == entrypoint }) {
-                let vm = VM(policy: policy)
-                return try await vm.executePlan(withContext: ctx, planIndex: planIndex)
-            }
+        guard let hit = planIndex[entrypoint] else {
+            throw RegoError(code: .unknownQuery, message: "query not found in plan: \(ctx.query)")
         }
-        throw RegoError(code: .unknownQuery, message: "query not found in plan: \(ctx.query)")
+        let vm = VM(policy: policies[hit.policyIdx])
+        return try await vm.executePlan(withContext: ctx, planIndex: hit.planIdx)
     }
 }
 

--- a/Sources/Rego/Store.swift
+++ b/Sources/Rego/Store.swift
@@ -10,6 +10,13 @@ extension OPA {
         /// Writes a value at the specified key path.
         /// - Parameter to: The path at which to return the value.
         mutating func write(to: StoreKeyPath, value: AST.RegoValue) async throws
+        /// Removes the value at the specified key path, including the leaf key
+        /// from its parent. Removing the root path resets the store to its empty state.
+        /// Objects are traversed by string key; arrays by integer index; a set at any
+        /// intermediate position throws `RegoError.internalError`.
+        /// - Throws: `RegoError.storePathNotFound` if any path segment is not found;
+        ///           `RegoError.internalError` if a set is encountered during traversal.
+        mutating func remove(at: StoreKeyPath) async throws
     }
 
     /// InMemoryStore is an in-memory implementation of ``OPA/Store``
@@ -38,6 +45,10 @@ struct NullStore: OPA.Store {
     mutating public func write(to: StoreKeyPath, value: AST.RegoValue) async throws {
         throw RegoError(code: .internalError, message: "not implemented!")
     }
+
+    mutating public func remove(at: StoreKeyPath) async throws {
+        throw RegoError(code: .internalError, message: "not implemented!")
+    }
 }
 
 extension OPA.InMemoryStore: OPA.Store {
@@ -48,13 +59,20 @@ extension OPA.InMemoryStore: OPA.Store {
     public func read(from path: StoreKeyPath) async throws -> AST.RegoValue {
         var current: AST.RegoValue = data
         for segment in path.segments {
-            guard case .object(let object) = current else {
+            switch current {
+            case .object(let o):
+                guard let next = o[.string(segment)] else {
+                    throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
+                }
+                current = next
+            case .array(let a):
+                guard let idx = Int(segment), idx >= 0, idx < a.count else {
+                    throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
+                }
+                current = a[idx]
+            default:
                 throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
             }
-            guard let next = object[.string(segment)] else {
-                throw RegoError(code: .storePathNotFound, message: "path not found: \(path)")
-            }
-            current = next
         }
 
         return current
@@ -63,5 +81,56 @@ extension OPA.InMemoryStore: OPA.Store {
     public mutating func write(to path: StoreKeyPath, value: AST.RegoValue) async throws {
         // TODO this is not achieving our goal of thread safety
         data = data.patch(with: value, at: path.segments)
+    }
+
+    public mutating func remove(at path: StoreKeyPath) async throws {
+        data = try applyRemove(data, at: path.segments[...], fullPath: path)
+    }
+}
+
+private func applyRemove(
+    _ value: AST.RegoValue,
+    at path: ArraySlice<String>,
+    fullPath: StoreKeyPath
+) throws -> AST.RegoValue {
+    guard !path.isEmpty else {
+        return .object([:])
+    }
+
+    let i = path.startIndex
+    let segment = path[i]
+    let rest = path[i.advanced(by: 1)...]
+
+    switch value {
+    case .object(var o):
+        let k = AST.RegoValue.string(segment)
+        guard let child = o[k] else {
+            throw RegoError(code: .storePathNotFound, message: "path not found: \(fullPath)")
+        }
+        if rest.isEmpty {
+            o.removeValue(forKey: k)
+            return .object(o)
+        }
+        o[k] = try applyRemove(child, at: rest, fullPath: fullPath)
+        return .object(o)
+
+    case .array(let a):
+        guard let idx = Int(segment), idx >= 0, idx < a.count else {
+            throw RegoError(code: .storePathNotFound, message: "path not found: \(fullPath)")
+        }
+        if rest.isEmpty {
+            var newArr = a
+            newArr.remove(at: idx)
+            return .array(newArr)
+        }
+        var newArr = a
+        newArr[idx] = try applyRemove(a[idx], at: rest, fullPath: fullPath)
+        return .array(newArr)
+
+    case .set:
+        throw RegoError(code: .internalError, message: "invalid data value encountered")
+
+    default:
+        throw RegoError(code: .storePathNotFound, message: "path not found: \(fullPath)")
     }
 }

--- a/Tests/ASTTests/RemovingTests.swift
+++ b/Tests/ASTTests/RemovingTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+@testable import AST
+
+@Suite
+struct RemovingTests {
+    struct TestCase {
+        var description: String
+        var data: AST.RegoValue
+        var path: [String]
+        var expected: AST.RegoValue
+    }
+
+    static var allTests: [TestCase] {
+        return [
+            TestCase(
+                description: "remove leaf",
+                data: .object([
+                    .string("foo"): .number(1),
+                    .string("bar"): .number(2),
+                ]),
+                path: ["foo"],
+                expected: .object([
+                    .string("bar"): .number(2)
+                ])
+            ),
+            TestCase(
+                description: "remove nested leaf, parent preserved even when emptied",
+                data: .object([
+                    .string("foo"): .object([
+                        .string("bar"): .number(1)
+                    ]),
+                    .string("baz"): .number(2),
+                ]),
+                path: ["foo", "bar"],
+                expected: .object([
+                    .string("foo"): .object([:]),
+                    .string("baz"): .number(2),
+                ])
+            ),
+            TestCase(
+                description: "remove non-existent leaf is no-op",
+                data: .object([
+                    .string("foo"): .number(1)
+                ]),
+                path: ["nope"],
+                expected: .object([
+                    .string("foo"): .number(1)
+                ])
+            ),
+            TestCase(
+                description: "remove through non-existent intermediate is no-op",
+                data: .object([
+                    .string("foo"): .number(1)
+                ]),
+                path: ["nope", "still", "missing"],
+                expected: .object([
+                    .string("foo"): .number(1)
+                ])
+            ),
+            TestCase(
+                description: "remove through non-object intermediate is no-op",
+                data: .object([
+                    .string("foo"): .number(1)
+                ]),
+                path: ["foo", "bar"],
+                expected: .object([
+                    .string("foo"): .number(1)
+                ])
+            ),
+            TestCase(
+                description: "empty path resets to empty object",
+                data: .object([
+                    .string("foo"): .number(1)
+                ]),
+                path: [],
+                expected: .object([:])
+            ),
+            TestCase(
+                description: "remove on non-object root is no-op",
+                data: .number(42),
+                path: ["foo"],
+                expected: .number(42)
+            ),
+            // Array element removal compacts the array (matches Store.applyRemove).
+            TestCase(
+                description: "remove array element by index compacts",
+                data: .array([.number(10), .number(20), .number(30)]),
+                path: ["1"],
+                expected: .array([.number(10), .number(30)])
+            ),
+            // Recurse through an array index into a nested object.
+            TestCase(
+                description: "remove object key reached through array index",
+                data: .object([
+                    .string("items"): .array([
+                        .object([.string("a"): .number(1), .string("b"): .number(2)])
+                    ])
+                ]),
+                path: ["items", "0", "a"],
+                expected: .object([
+                    .string("items"): .array([
+                        .object([.string("b"): .number(2)])
+                    ])
+                ])
+            ),
+            // Array no-op guards: non-integer, out-of-bounds, and negative index.
+            TestCase(
+                description: "array non-integer index is no-op",
+                data: .array([.number(1), .number(2)]),
+                path: ["foo"],
+                expected: .array([.number(1), .number(2)])
+            ),
+            TestCase(
+                description: "array out-of-bounds index is no-op",
+                data: .array([.number(1), .number(2)]),
+                path: ["5"],
+                expected: .array([.number(1), .number(2)])
+            ),
+            TestCase(
+                description: "array negative index is no-op",
+                data: .array([.number(1), .number(2)]),
+                path: ["-1"],
+                expected: .array([.number(1), .number(2)])
+            ),
+        ]
+    }
+
+    @Test(arguments: allTests)
+    func testRemoving(tc: TestCase) throws {
+        let original = tc.data
+        let result = tc.data.removing(at: tc.path)
+        #expect(result == tc.expected)
+
+        // Original should be unmodified.
+        #expect(tc.data == original)
+    }
+
+    @Test
+    func testRemovingDeepLeafLeavesAncestorsIntact() throws {
+        let v = AST.RegoValue.object([
+            .string("a"): .object([
+                .string("b"): .object([
+                    .string("c"): .number(1),
+                    .string("d"): .number(2),
+                ])
+            ])
+        ])
+        let result = v.removing(at: ["a", "b", "c"])
+        let expected = AST.RegoValue.object([
+            .string("a"): .object([
+                .string("b"): .object([
+                    .string("d"): .number(2)
+                ])
+            ])
+        ])
+        #expect(result == expected)
+    }
+}
+
+extension RemovingTests.TestCase: CustomTestStringConvertible {
+    var testDescription: String { description }
+}

--- a/Tests/RegoTests/EnginePrepareTests.swift
+++ b/Tests/RegoTests/EnginePrepareTests.swift
@@ -1,0 +1,182 @@
+import AST
+import Foundation
+import IR
+import Testing
+
+@testable import Rego
+
+/// Engine-level tests covering how the store is affected by the
+/// store writes done during ``OPA/Engine/prepareForEvaluation(query:)``.
+@Suite("EnginePrepareTests")
+struct EnginePrepareTests {
+
+    // MARK: - User data preservation across query prepare
+
+    @Test("User data outside bundle roots survives prepareForEvaluation")
+    func testUserDataSurvivesPrepare() async throws {
+        // Construct a store with example data at populated `/data/user/preference`.
+        // Use the same helper as the cross-bundle data tests to build a user
+        // IR policy that walks down to `data.user.preference`.
+        // With no bundles in use, the engine should not erase the store
+        // contents.
+        let userSeed: AST.RegoValue = .object([
+            "data": .object([
+                "user": .object(["preference": .number(99)])
+            ])
+        ])
+
+        // Convert the generated JSON to an IR.Policy.
+        let policyBundle = try BundleCrossBundleDataTests.makePolicyOnlyBundle(
+            decisionPath: "user/pref",
+            dataPath: "user/preference"
+        )
+        let planJSON = policyBundle.planFiles.first!.data
+        let irPolicy = try IR.Policy(jsonData: planJSON)
+
+        var engine = OPA.Engine(
+            policies: [irPolicy],
+            store: OPA.InMemoryStore(initialData: userSeed)
+        )
+        let pq = try await engine.prepareForEvaluation(query: "data.user.pref")
+        let result = try await pq.evaluate(input: .object([:]))
+
+        // If the engine had wiped `/data` on prepare, this would be empty.
+        #expect(result == ResultSet([.object(["result": .number(99)])]))
+    }
+
+    // MARK: - Multiple prepare correctness
+
+    @Test("Preparing the same engine twice produces consistent results")
+    func testPrepareIsIdempotent() async throws {
+        let policyBundle = try BundleCrossBundleDataTests.makePolicyOnlyBundle(
+            decisionPath: "example/allow",
+            dataPath: "config/example/value"
+        )
+        let dataBundle = try BundleCrossBundleDataTests.makeDataOnlyBundle(
+            dataPath: "config/example/value",
+            value: .number(42)
+        )
+
+        var engine = OPA.Engine(bundles: [
+            "policy": policyBundle,
+            "data": dataBundle,
+        ])
+
+        let pq1 = try await engine.prepareForEvaluation(query: "data/example/allow")
+        let r1 = try await pq1.evaluate(input: .object([:]))
+        #expect(r1 == ResultSet([.object(["result": .number(42)])]))
+
+        // Second prepare: erases the previously written bundle roots and
+        // writes the same data again. The result should be identical.
+        let pq2 = try await engine.prepareForEvaluation(query: "data/example/allow")
+        let r2 = try await pq2.evaluate(input: .object([:]))
+        #expect(r2 == r1)
+    }
+
+    @Test("Multiple bundles with disjoint roots evaluate together after prepare")
+    func testMultipleDisjointBundlesEval() async throws {
+        // Exercises the  happy path: a policy bundle owning the
+        // decision-path root, alongside a data-only bundle owning a
+        // disjoint data root.
+        let policyBundle = try BundleCrossBundleDataTests.makePolicyOnlyBundle(
+            decisionPath: "bundle/allow",
+            dataPath: "config/example/value"
+        )
+        let dataBundle = try BundleCrossBundleDataTests.makeDataOnlyBundle(
+            dataPath: "config/example/value",
+            value: .number(11)
+        )
+
+        var engine = OPA.Engine(bundles: [
+            "policy": policyBundle,
+            "data": dataBundle,
+        ])
+        let pq = try await engine.prepareForEvaluation(query: "data/bundle/allow")
+        let result = try await pq.evaluate(input: .object([:]))
+        #expect(result == ResultSet([.object(["result": .number(11)])]))
+    }
+
+    @Test("Empty-bundle engine does not crash on read of /data")
+    func testPolicyOnlyBundleStillProducesData() async throws {
+        // The VM unconditionally reads `/data`, so the engine must
+        // ensure that key exists even when no bundle wrote anything
+        // into the store.
+        let policyBundle = try BundleCrossBundleDataTests.makePolicyOnlyBundle(
+            decisionPath: "example/allow",
+            dataPath: "config/feature/enabled"
+        )
+        var engine = OPA.Engine(bundles: ["policy": policyBundle])
+
+        let pq = try await engine.prepareForEvaluation(query: "data/example/allow")
+        let result = try await pq.evaluate(input: .object([:]))
+        // Policy fails at runtime (data is missing), and gives an empty
+        // result set.
+        #expect(result == ResultSet([]))
+    }
+
+    // MARK: - User IR policies vs. bundle roots
+
+    @Test("User IR plan whose name falls under a bundle root is rejected")
+    func testUserPolicyUnderBundleRootRejected() throws {
+        // Bundle owns the `app/` root. A user-supplied IR policy whose
+        // plan name lives at `app/admin/allow` is reserving a name in a
+        // subtree the bundle owns, even though the bundle ships no plan
+        // by that exact name. The Engine should reject this at prepare
+        // time, before reaching the IREvaluator's name-uniqueness check.
+        let bundle = try IREvaluatorValidationTests.makeTestBundle(
+            roots: ["app"],
+            planNames: ["app/allow"]
+        )
+        let userPolicy = IREvaluatorValidationTests.makeIRPolicy(planNames: ["app/admin/allow"])
+
+        do {
+            try OPA.Engine.checkUserPoliciesAgainstBundleRoots(
+                userPolicies: [userPolicy],
+                bundles: ["b": bundle]
+            )
+            Issue.record("expected planNameConflictError")
+        } catch let err as RegoError {
+            #expect(err.code == .planNameConflictError)
+            #expect(err.message.contains("app/admin/allow"))
+            #expect(err.message.contains("bundle:b"))
+        }
+    }
+
+    @Test("User IR plan with a name disjoint from all bundle roots is accepted")
+    func testUserPolicyOutsideBundleRootsAccepted() throws {
+        let bundle = try IREvaluatorValidationTests.makeTestBundle(
+            roots: ["app"],
+            planNames: ["app/allow"]
+        )
+        // `tooling/...` is disjoint from `app/...`, and should pass.
+        let userPolicy = IREvaluatorValidationTests.makeIRPolicy(planNames: ["tooling/lint"])
+
+        try OPA.Engine.checkUserPoliciesAgainstBundleRoots(
+            userPolicies: [userPolicy],
+            bundles: ["b": bundle]
+        )
+    }
+
+    @Test("User IR plan name overlapping multiple bundle roots reports all owners")
+    func testUserPolicyOverlapAcrossMultipleBundles() throws {
+        // Two bundles each declare an empty root (matches everything).
+        // A user plan named `shared/x` should be reported as conflicting
+        // against both, with bundle owners listed in sorted order.
+        let b1 = try IREvaluatorValidationTests.makeTestBundle(roots: [""], planNames: ["b1/p"])
+        let b2 = try IREvaluatorValidationTests.makeTestBundle(roots: [""], planNames: ["b2/p"])
+        let userPolicy = IREvaluatorValidationTests.makeIRPolicy(planNames: ["shared/x"])
+
+        do {
+            try OPA.Engine.checkUserPoliciesAgainstBundleRoots(
+                userPolicies: [userPolicy],
+                bundles: ["b1": b1, "b2": b2]
+            )
+            Issue.record("expected planNameConflictError")
+        } catch let err as RegoError {
+            #expect(err.code == .planNameConflictError)
+            #expect(err.message.contains("shared/x"))
+            #expect(err.message.contains("bundle:b1"))
+            #expect(err.message.contains("bundle:b2"))
+        }
+    }
+}

--- a/Tests/RegoTests/IREvaluatorValidationTests.swift
+++ b/Tests/RegoTests/IREvaluatorValidationTests.swift
@@ -1,0 +1,191 @@
+import AST
+import Foundation
+import IR
+import Testing
+
+@testable import Rego
+
+/// Tests for the new validation checks performed by ``IREvaluator(bundles:userPolicies:)``:
+/// - bundle plan names must lie under that bundle's declared roots, and
+/// - plan names must be unique across the entire set of bundles + user policies.
+@Suite("IREvaluatorValidationTests")
+struct IREvaluatorValidationTests {
+
+    // MARK: - Helpers
+
+    /// Build an `IR.Policy` with empty plans for the given names.
+    /// This works for these tests because we only care about
+    /// construction-time checks, and don't test evaluation at all.
+    static func makeIRPolicy(planNames: [String]) -> IR.Policy {
+        let plans = planNames.map { IR.Plan(name: $0, blocks: []) }
+        return IR.Policy(
+            staticData: nil,
+            plans: IR.Plans(plans: plans),
+            funcs: IR.Funcs(funcs: [])
+        )
+    }
+
+    /// Build a test `OPA.Bundle` whose single plan file encodes the given
+    /// IR policy. The bundle has no data under its roots.
+    static func makeTestBundle(roots: [String], planNames: [String]) throws -> OPA.Bundle {
+        let policy = makeIRPolicy(planNames: planNames)
+        let serializedPolicy = try JSONEncoder().encode(policy)
+        let manifest = OPA.Manifest(roots: roots)
+        let planFile = BundleFile(
+            url: URL(fileURLWithPath: "/synthetic/plan.json"),
+            data: serializedPolicy
+        )
+        return try OPA.Bundle(manifest: manifest, planFiles: [planFile])
+    }
+
+    // MARK: - Plan contained under roots check
+
+    @Test
+    func testPlanUnderBundleRootSucceeds() throws {
+        let bundle = try Self.makeTestBundle(roots: ["foo"], planNames: ["foo/allow"])
+        _ = try IREvaluator(bundles: ["b": bundle])
+    }
+
+    @Test
+    func testPlanUnderEmptyRootSucceeds() throws {
+        let bundle = try Self.makeTestBundle(roots: [""], planNames: ["foo/bar"])
+        _ = try IREvaluator(bundles: ["b": bundle])
+    }
+
+    @Test
+    func testPlanOutsideBundleRootsThrows() throws {
+        let bundle = try Self.makeTestBundle(roots: ["foo"], planNames: ["bar/oops"])
+        let err = try requireThrows(throws: RegoError.self) {
+            try IREvaluator(bundles: ["b": bundle])
+        }
+        #expect(err.code == .planEscapedBundleRoots)
+        #expect(err.message.contains("bar/oops"))
+        #expect(err.message.contains("'b'"))
+    }
+
+    @Test
+    func testPlanSegmentMustMatchOnBoundaries() throws {
+        // root "foo" must NOT match plan "foobar/x". (path segment-aware matching)
+        let bundle = try Self.makeTestBundle(roots: ["foo"], planNames: ["foobar/x"])
+        let err = try requireThrows(throws: RegoError.self) {
+            try IREvaluator(bundles: ["b": bundle])
+        }
+        #expect(err.code == .planEscapedBundleRoots)
+    }
+
+    // MARK: - Plan-name uniqueness
+
+    @Test
+    func testTwoBundlesWithSamePlanNameThrows() throws {
+        // Use distinct roots so the bundle-overlap check passes. This lets the
+        // us reach the plan-name check for failing.
+        let b1 = try Self.makeTestBundle(roots: ["a"], planNames: ["a/allow", "a/x"])
+        let b2 = try Self.makeTestBundle(roots: ["b"], planNames: ["b/allow"])
+        // Make a collision by giving ensuring both bundles share the empty root
+        let bShared1 = try Self.makeTestBundle(roots: [""], planNames: ["shared/p"])
+        let bShared2 = try Self.makeTestBundle(roots: [""], planNames: ["shared/p"])
+
+        // Sanity: distinct names is fine.
+        _ = try IREvaluator(bundles: ["b1": b1, "b2": b2])
+
+        // The bundle overlap check only happens in the Engine. If we
+        // construct an IREvaluator directly, we can bypass that check,
+        // and exercise our name uniqueness check.
+        let err = try requireThrows(throws: RegoError.self) {
+            try IREvaluator(bundles: ["x": bShared1, "y": bShared2])
+        }
+        #expect(err.code == .planNameConflictError)
+        #expect(err.message.contains("shared/p"))
+        #expect(err.message.contains("bundle:x"))
+        #expect(err.message.contains("bundle:y"))
+    }
+
+    @Test
+    func testBundleAndUserPolicyWithSamePlanNameThrows() throws {
+        let bundle = try Self.makeTestBundle(roots: [""], planNames: ["x/y"])
+        let userPolicy = Self.makeIRPolicy(planNames: ["x/y"])
+        let err = try requireThrows(throws: RegoError.self) {
+            try IREvaluator(bundles: ["b": bundle], userPolicies: [userPolicy])
+        }
+        #expect(err.code == .planNameConflictError)
+        #expect(err.message.contains("x/y"))
+        #expect(err.message.contains("bundle:b"))
+        #expect(err.message.contains("user:#0"))
+    }
+
+    @Test
+    func testTwoUserPoliciesWithSamePlanNameThrows() throws {
+        let p1 = Self.makeIRPolicy(planNames: ["foo/bar"])
+        let p2 = Self.makeIRPolicy(planNames: ["foo/bar"])
+        let err = try requireThrows(throws: RegoError.self) {
+            try IREvaluator(bundles: [:], userPolicies: [p1, p2])
+        }
+        #expect(err.code == .planNameConflictError)
+        #expect(err.message.contains("foo/bar"))
+    }
+
+    // MARK: - Bundle and user policies
+
+    @Test
+    func testBundleAndUserPolicyWithDistinctPlanNamesCoexist() async throws {
+        let bundle = try Self.makeTestBundle(roots: ["bundle"], planNames: ["bundle/allow"])
+        let userPolicy = Self.makeIRPolicy(planNames: ["user/decision"])
+
+        let evaluator = try IREvaluator(bundles: ["b": bundle], userPolicies: [userPolicy])
+
+        // Both plan names should be reachable: evaluating either query
+        // executes its (empty) plan and returns an empty result set rather
+        // than throwing unknownQuery. A name from neither source must throw.
+        let store = OPA.InMemoryStore(initialData: .object(["data": .object([:])]))
+        func evaluate(_ query: String) async throws -> ResultSet {
+            try await evaluator.evaluate(
+                withContext: EvaluationContext(query: query, input: .object([:]), store: store))
+        }
+
+        #expect(try await evaluate("data.bundle.allow") == ResultSet.empty)
+        #expect(try await evaluate("data.user.decision") == ResultSet.empty)
+
+        let err = try await requireThrows(throws: RegoError.self) {
+            _ = try await evaluate("data.nonexistent")
+        }
+        #expect(err.code == .unknownQuery)
+    }
+}
+
+// Note(philip): These functions emulate modern #require(throws:) behavior in
+// older versions of Swift (<= 6.0.3), which do not return the caught error.
+// They should be replaced with normal usage of #require as soon as 6.0.3
+// support is dropped. See also the copy in CapabilityEvaluatorTests.swift.
+private func requireThrows<E: Error & Sendable, R>(
+    throws errorType: E.Type,
+    _ comment: String = "",
+    operation: () throws -> R
+) throws -> E {
+    do {
+        _ = try operation()
+        #expect(Bool(false), "Expected \(errorType) to be thrown. \(comment)")
+        fatalError("This should never be reached")
+    } catch let error as E {
+        return error
+    } catch {
+        #expect(Bool(false), "Expected \(errorType) but got \(type(of: error)). \(comment)")
+        fatalError("This should never be reached")
+    }
+}
+
+private func requireThrows<E: Error & Sendable, R>(
+    throws errorType: E.Type,
+    _ comment: String = "",
+    operation: () async throws -> R
+) async throws -> E {
+    do {
+        _ = try await operation()
+        #expect(Bool(false), "Expected \(errorType) to be thrown. \(comment)")
+        fatalError("This should never be reached")
+    } catch let error as E {
+        return error
+    } catch {
+        #expect(Bool(false), "Expected \(errorType) but got \(type(of: error)). \(comment)")
+        fatalError("This should never be reached")
+    }
+}

--- a/Tests/RegoTests/RootPathsContainTests.swift
+++ b/Tests/RegoTests/RootPathsContainTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import Rego
+
+@Suite
+struct RootPathsContainTests {
+    struct TestCase {
+        let description: String
+        let roots: [String]
+        let path: String
+        let expected: Bool
+    }
+
+    static var allTests: [TestCase] {
+        return [
+            // Empty root cases
+            TestCase(description: "empty roots list", roots: [], path: "foo/bar", expected: false),
+            TestCase(description: "empty-string root owns all paths", roots: [""], path: "foo/bar", expected: true),
+            TestCase(description: "slash root is empty", roots: ["/"], path: "foo/bar", expected: true),
+            TestCase(description: "empty root with empty path", roots: [""], path: "", expected: true),
+            // Exact match
+            TestCase(description: "exact match", roots: ["foo"], path: "foo", expected: true),
+            TestCase(description: "exact nested match", roots: ["foo/bar"], path: "foo/bar", expected: true),
+            // Prefix match
+            TestCase(description: "root prefixes path", roots: ["foo"], path: "foo/bar", expected: true),
+            TestCase(
+                description: "deep root prefixes deeper path", roots: ["foo/bar"], path: "foo/bar/baz", expected: true),
+            // Non-match: segment-aware (the OPA invariant)
+            TestCase(
+                description: "segment-aware: foo not a prefix of foobar", roots: ["foo"], path: "foobar",
+                expected: false),
+            TestCase(description: "deeper root, shorter path", roots: ["foo/bar"], path: "foo", expected: false),
+            TestCase(
+                description: "sibling segment doesn't match", roots: ["foo/bar"], path: "foo/baz", expected: false),
+            // Multi-root: at least one matches
+            TestCase(description: "multi-root, second matches", roots: ["a", "b"], path: "b/c", expected: true),
+            TestCase(description: "multi-root, none match", roots: ["a", "b"], path: "c/d", expected: false),
+            // Slash trimming on roots and paths.
+            TestCase(description: "leading slash on root", roots: ["/foo"], path: "foo/bar", expected: true),
+            TestCase(description: "trailing slash on root", roots: ["foo/"], path: "foo/bar", expected: true),
+            TestCase(description: "leading slash on path", roots: ["foo"], path: "/foo/bar", expected: true),
+            TestCase(description: "trailing slash on path", roots: ["foo"], path: "foo/bar/", expected: true),
+            // Segment-aware non-match across a "/" boundary.
+            TestCase(
+                description: "/a/b/c vs root /ab/c is not a match", roots: ["/ab/c"], path: "/a/b/c",
+                expected: false),
+            // Empty path against a non-empty root.
+            TestCase(description: "non-empty root with empty path", roots: ["foo"], path: "", expected: false),
+            // Empty root entry mixed in with a non-empty one.
+            TestCase(
+                description: "multi-root with empty root entry matches anything", roots: ["a", ""],
+                path: "z/y/x", expected: true),
+        ]
+    }
+
+    @Test(arguments: allTests)
+    func testRootPathsContain(tc: TestCase) {
+        #expect(OPA.Bundle.rootPathsContain(tc.roots, tc.path) == tc.expected, "\(tc.description)")
+    }
+}
+
+extension RootPathsContainTests.TestCase: CustomTestStringConvertible {
+    var testDescription: String { description }
+}

--- a/Tests/RegoTests/StoreTests.swift
+++ b/Tests/RegoTests/StoreTests.swift
@@ -27,7 +27,19 @@ struct StoreTests {
                 data: #" {"data": {"foo": {"bar": 42}}} "#.data(using: .utf8)!,
                 path: StoreKeyPath(["data", "foo", "bar"]),
                 expected: .number(42)
-            )
+            ),
+            TestCase(
+                description: "array traversal by integer index",
+                data: #" {"data": [10, 20, 30]} "#.data(using: .utf8)!,
+                path: StoreKeyPath(["data", "1"]),
+                expected: .number(20)
+            ),
+            TestCase(
+                description: "mixed object then array traversal",
+                data: #" {"items": [{"val": 7}]} "#.data(using: .utf8)!,
+                path: StoreKeyPath(["items", "0", "val"]),
+                expected: .number(7)
+            ),
         ]
     }
 
@@ -38,7 +50,25 @@ struct StoreTests {
                 data: #" {"data": {"foo": {"bar": 42}}} "#.data(using: .utf8)!,
                 path: StoreKeyPath(["data", "nope", "bar"]),
                 expectedErr: RegoError.Code.storePathNotFound
-            )
+            ),
+            ErrorCase(
+                description: "array index out of bounds",
+                data: #" {"data": [1, 2, 3]} "#.data(using: .utf8)!,
+                path: StoreKeyPath(["data", "99"]),
+                expectedErr: RegoError.Code.storePathNotFound
+            ),
+            ErrorCase(
+                description: "array index not an integer",
+                data: #" {"data": [1, 2, 3]} "#.data(using: .utf8)!,
+                path: StoreKeyPath(["data", "foo"]),
+                expectedErr: RegoError.Code.storePathNotFound
+            ),
+            ErrorCase(
+                description: "scalar at intermediate path segment",
+                data: #" {"data": 42} "#.data(using: .utf8)!,
+                path: StoreKeyPath(["data", "key"]),
+                expectedErr: RegoError.Code.storePathNotFound
+            ),
         ]
     }
 
@@ -66,6 +96,141 @@ struct StoreTests {
             let b: Bool = regoError.code == tc.expectedErr
             return b
         }
+    }
+
+    @Test
+    func testRemoveLeafRemovesKeyFromParent() async throws {
+        let root = try AST.RegoValue(
+            jsonData: #" {"data": {"foo": {"bar": 1, "baz": 2}}} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        try await store.remove(at: StoreKeyPath(["data", "foo", "bar"]))
+
+        let parent = try await store.read(from: StoreKeyPath(["data", "foo"]))
+        #expect(parent == .object([.string("baz"): .number(2)]))
+    }
+
+    @Test
+    func testRemoveNonExistentKeyThrowsNotFound() async throws {
+        let root = try AST.RegoValue(jsonData: #" {"data": {"foo": 1}} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        await #expect() {
+            try await store.remove(at: StoreKeyPath(["data", "nope"]))
+        } throws: { error in
+            guard let regoError = error as? RegoError else { return false }
+            return regoError.code == .storePathNotFound
+        }
+    }
+
+    @Test
+    func testRemoveObjectKeyThroughArrayTraversal() async throws {
+        let root = try AST.RegoValue(
+            jsonData: #" {"items": [{"a": 1}, {"b": 2}]} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        try await store.remove(at: StoreKeyPath(["items", "0", "a"]))
+
+        // Element 0 is modified in-place (key deleted); array is not compacted.
+        let result = try await store.read(from: StoreKeyPath(["items"]))
+        #expect(result == .array([.object([:]), .object([.string("b"): .number(2)])]))
+    }
+
+    @Test
+    func testRemoveNonExistentKeyThroughArrayThrowsNotFound() async throws {
+        let root = try AST.RegoValue(
+            jsonData: #" {"items": [{"a": 1}]} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        await #expect() {
+            try await store.remove(at: StoreKeyPath(["items", "0", "missing"]))
+        } throws: { error in
+            guard let regoError = error as? RegoError else { return false }
+            return regoError.code == .storePathNotFound
+        }
+    }
+
+    @Test
+    func testRemoveScalarIntermediateThrowsNotFound() async throws {
+        let root = try AST.RegoValue(
+            jsonData: #" {"data": {"foo": 42}} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        await #expect() {
+            try await store.remove(at: StoreKeyPath(["data", "foo", "deeper"]))
+        } throws: { error in
+            guard let regoError = error as? RegoError else { return false }
+            return regoError.code == .storePathNotFound
+        }
+    }
+
+    @Test
+    func testRemoveArrayElement() async throws {
+        let root = try AST.RegoValue(jsonData: #" {"items": [10, 20, 30]} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        try await store.remove(at: StoreKeyPath(["items", "1"]))
+
+        let result = try await store.read(from: StoreKeyPath(["items"]))
+        #expect(result == .array([.number(10), .number(30)]))
+    }
+
+    @Test
+    func testRemoveArrayIndexOOBThrowsNotFound() async throws {
+        let root = try AST.RegoValue(jsonData: #" {"items": [1, 2, 3]} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        await #expect() {
+            try await store.remove(at: StoreKeyPath(["items", "99"]))
+        } throws: { error in
+            guard let regoError = error as? RegoError else { return false }
+            return regoError.code == .storePathNotFound
+        }
+    }
+
+    @Test
+    func testRemoveThroughSetThrowsInternalError() async throws {
+        // Construct a value containing a set directly in Swift since JSON cannot encode sets.
+        let root = AST.RegoValue.object([
+            .string("data"): .set([.string("a"), .string("b")])
+        ])
+        var store = OPA.InMemoryStore(initialData: root)
+
+        await #expect() {
+            try await store.remove(at: StoreKeyPath(["data", "a"]))
+        } throws: { error in
+            guard let regoError = error as? RegoError else { return false }
+            return regoError.code == .internalError
+        }
+    }
+
+    @Test
+    func testRemoveAtRootResetsToEmptyObject() async throws {
+        let root = try AST.RegoValue(jsonData: #" {"foo": 1} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        try await store.remove(at: StoreKeyPath([]))
+
+        let value = try await store.read(from: StoreKeyPath([]))
+        #expect(value == .object([:]))
+    }
+
+    @Test
+    func testRemovePreservesEmptiedAncestor() async throws {
+        let root = try AST.RegoValue(
+            jsonData: #" {"data": {"foo": {"bar": 1}, "baz": 2}} "#.data(using: .utf8)!)
+        var store = OPA.InMemoryStore(initialData: root)
+
+        try await store.remove(at: StoreKeyPath(["data", "foo", "bar"]))
+
+        // foo is preserved as an empty object, baz untouched.
+        let dataValue = try await store.read(from: StoreKeyPath(["data"]))
+        #expect(
+            dataValue
+                == .object([
+                    .string("foo"): .object([:]),
+                    .string("baz"): .number(2),
+                ]))
     }
 }
 


### PR DESCRIPTION
### What code changed, and why?

This commit includes improvements to plan name validation, and adds a remove operation for the store.

The Engine now validates that plans are contained under the roots of their parent bundles and also supports loading user-provided IR policies alongside bundles now. The validation ensures that plan names don't conflict across bundles or user-provided IR policies, and prevent user IR policies from claiming paths owned by bundles.

The store also now supports user-supplied data living alongside bundle-owned data. `prepareForEvaluation` now does not erase the entire store, and only clears out the old/stale bundle roots before writing the new set of bundle data/roots to the store. Any paths outside of that set are left untouched.

The `Store` protocol now supports a remove operation as well, bringing us closer to the OPA store's functionality.

### How to test

 - New tests have been added under `Tests/ASTTests/` and `Tests/RegoTests/`, and are automatically picked up by `make test`.

### Notes for reviewers

 - Only 360 LOC (~1/3 of the PR size) is actual library code changes. The other 2/3 is new tests.

### Related Resources

