### PR TITLE
perf: Replace ==/!- .undefined comparisons with case .undefined pattern matching

### DIFF
--- a/Sources/AST/RegoValue.swift
+++ b/Sources/AST/RegoValue.swift
@@ -107,3 +107,41 @@ extension RegoValue {
         }
     }
 }
+
+// MARK: - Equatable
+
+extension RegoValue {
+    /// Explicit Equatable implementation, marked @inline(__always) so every intra-module call site
+    /// gets a direct discriminant tag comparison rather than a non-inlined
+    /// `__derived_enum_equals` dispatch. Semantically identical to the synthesized
+    /// conformance and consistent with the synthesized Hashable implementation.
+    @inline(__always)
+    public static func == (lhs: RegoValue, rhs: RegoValue) -> Bool {
+        switch lhs {
+        case .undefined:
+            if case .undefined = rhs { return true }
+            return false
+        case .null:
+            if case .null = rhs { return true }
+            return false
+        case .boolean(let a):
+            if case .boolean(let b) = rhs { return a == b }
+            return false
+        case .number(let a):
+            if case .number(let b) = rhs { return a == b }
+            return false
+        case .string(let a):
+            if case .string(let b) = rhs { return a == b }
+            return false
+        case .array(let a):
+            if case .array(let b) = rhs { return a == b }
+            return false
+        case .object(let a):
+            if case .object(let b) = rhs { return a == b }
+            return false
+        case .set(let a):
+            if case .set(let b) = rhs { return a == b }
+            return false
+        }
+    }
+}

--- a/Sources/Rego/VM+Instructions.swift
+++ b/Sources/Rego/VM+Instructions.swift
@@ -17,9 +17,7 @@ extension VM {
         let (valueOp, _) = context.decodeOperand(from: payload, at: start + 4)
         let value = context.resolveUnchecked(valueOp)
 
-        guard value != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = value { return failWithUndefinedBytecode(context: context) }
 
         let array = context.resolveLocal(idx: arrayIdx)
         context.locals[arrayIdx] = nil  // drop reference before var binding to avoid CoW copy
@@ -49,16 +47,18 @@ extension VM {
         let (sourceOp, _) = context.decodeOperand(from: payload, at: start + 4)
         let source = context.resolveUnchecked(sourceOp)
 
-        let currentValue = context.resolveLocal(idx: target)
-        guard currentValue == .undefined else {
-            // Repeated assignments can only be of the same value, otherwise error
-            if currentValue != source {
+        // Direct locals read (not resolveLocal): the raw Optional distinguishes unbound (nil
+        // or .undefined) from a previously bound value in one switch, without needing to
+        // coalesce nil first and then compare again.
+        switch context.locals[target] {
+        case nil, .some(.undefined):
+            context.assignLocal(idx: target, value: source)
+        case .some(let v):
+            if v != source {
+                // Repeated assignments can only be of the same value, otherwise error
                 throw RegoError(code: .assignOnceError, message: "local already assigned with different value")
             }
-            return .success
         }
-
-        context.assignLocal(idx: target, value: source)
         return .success
     }
 
@@ -138,9 +138,7 @@ extension VM {
                 op1: (UInt32(op1.type.rawValue) << 30) | op1.value
             )
             if let cached = context[memoKey] {
-                guard cached != .undefined else {
-                    return failWithUndefinedBytecode(context: context)
-                }
+                if case .undefined = cached { return failWithUndefinedBytecode(context: context) }
                 context.assignLocal(idx: result, value: cached)
                 return .success
             }
@@ -156,9 +154,7 @@ extension VM {
 
             let returnValue = try await executeFunction(context: context, function: function, args: memoArgs)
             context[memoKey] = returnValue
-            guard returnValue != .undefined else {
-                return failWithUndefinedBytecode(context: context)
-            }
+            if case .undefined = returnValue { return failWithUndefinedBytecode(context: context) }
             context.assignLocal(idx: result, value: returnValue)
             return .success
         }
@@ -184,9 +180,7 @@ extension VM {
         if encodedFuncIndex & 0x8000_0000 != 0 {
             // Builtin call: fail immediately if any argument is undefined
             for argValue in args {
-                guard argValue != .undefined else {
-                    return failWithUndefinedBytecode(context: context)
-                }
+                if case .undefined = argValue { return failWithUndefinedBytecode(context: context) }
             }
 
             let stringIndex = Int(encodedFuncIndex & 0x7FFF_FFFF)
@@ -228,10 +222,7 @@ extension VM {
 
         let returnValue = try await executeFunction(context: context, function: function, args: args)
 
-        guard returnValue != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
-
+        if case .undefined = returnValue { return failWithUndefinedBytecode(context: context) }
         context.assignLocal(idx: result, value: returnValue)
         return .success
     }
@@ -291,9 +282,7 @@ extension VM {
 
         let returnValue = try await executeFunction(context: context, function: function, args: args)
 
-        guard returnValue != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = returnValue { return failWithUndefinedBytecode(context: context) }
         context.assignLocal(idx: result, value: returnValue)
 
         return .success
@@ -330,9 +319,7 @@ extension VM {
             result = .undefined
         }
 
-        guard result != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = result { return failWithUndefinedBytecode(context: context) }
 
         context.assignLocal(idx: target, value: result)
         return .success
@@ -374,9 +361,7 @@ extension VM {
         let source = context.decodeLocal(from: payload, at: start)
         let value = context.resolveLocal(idx: source)
 
-        guard value != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = value { return failWithUndefinedBytecode(context: context) }
         return .success
     }
 
@@ -411,7 +396,7 @@ extension VM {
         let source = context.decodeLocal(from: payload, at: start)
         let value = context.resolveLocal(idx: source)
 
-        guard value == .undefined else {
+        guard case .undefined = value else {
             return failWithUndefinedBytecode(context: context)
         }
         return .success
@@ -520,9 +505,9 @@ extension VM {
         let b = context.resolveUnchecked(bOp)
 
         // This statement is undefined if either operand is undefined or if a equals b
-        if a == .undefined || b == .undefined || a == b {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = a { return failWithUndefinedBytecode(context: context) }
+        if case .undefined = b { return failWithUndefinedBytecode(context: context) }
+        if a == b { return failWithUndefinedBytecode(context: context) }
 
         return .success
     }
@@ -564,9 +549,8 @@ extension VM {
         let (valueOp, _) = context.decodeOperand(from: payload, at: start + 4 + keySize)
         let value = context.resolveUnchecked(valueOp)
 
-        guard key != .undefined, value != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = key { return failWithUndefinedBytecode(context: context) }
+        if case .undefined = value { return failWithUndefinedBytecode(context: context) }
 
         let objectValue = context.resolveLocal(idx: object)
         context.locals[object] = nil  // drop reference before var binding to avoid CoW copy
@@ -597,9 +581,7 @@ extension VM {
         let (valueOp, _) = context.decodeOperand(from: payload, at: start + 4 + keySize)
         let value = context.resolveUnchecked(valueOp)
 
-        guard value != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = value { return failWithUndefinedBytecode(context: context) }
 
         let objectValue = context.resolveLocal(idx: object)
         context.locals[object] = nil  // drop reference before var binding to avoid CoW copy
@@ -653,9 +635,7 @@ extension VM {
         let value = context.decodeLocal(from: payload, at: start)
         let regoValue = context.resolveLocal(idx: value)
 
-        guard regoValue != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = regoValue { return failWithUndefinedBytecode(context: context) }
 
         context.results.insert(regoValue)
         return .success
@@ -686,9 +666,8 @@ extension VM {
         let sourceValue = context.resolveLocal(idx: source)
 
         // Ensure source is defined and is a collection
-        guard sourceValue != .undefined, sourceValue.isCollection else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = sourceValue { return failWithUndefinedBytecode(context: context) }
+        guard sourceValue.isCollection else { return failWithUndefinedBytecode(context: context) }
 
         // Iterate over the collection, propagating break and return from the scan body.
         // OPA semantics: break exits the scan loop (consuming one nesting level),
@@ -745,9 +724,7 @@ extension VM {
         let (valueOp, _) = context.decodeOperand(from: payload, at: start + 4)
         let value = context.resolveUnchecked(valueOp)
 
-        guard value != .undefined else {
-            return failWithUndefinedBytecode(context: context)
-        }
+        if case .undefined = value { return failWithUndefinedBytecode(context: context) }
 
         let setValue = context.resolveLocal(idx: set)
         context.locals[set] = nil  // drop reference before var binding to avoid CoW copy

--- a/Sources/Rego/VM.swift
+++ b/Sources/Rego/VM.swift
@@ -152,19 +152,30 @@ extension VM {
             switch opcodeRaw {
             // ── Compact opcodes (rawValues 35–41): operand encoded in `length` field ─────────
             case Int(Opcode.isDefined1.rawValue):
-                if context.resolveLocal(idx: Local(UInt32(length))) == .undefined { return .undefined }
-                continue
+                // Direct locals access (not resolveLocal): a single switch on the raw Optional
+                // handles nil and .some(.undefined) in one step, avoiding nil-coalescing.
+                // See resolveLocal docs for why this exception exists.
+                switch context.locals[Local(UInt32(length))] {
+                case nil, .some(.undefined): return .undefined
+                default: continue
+                }
             case Int(Opcode.isUndefined1.rawValue):
-                if context.resolveLocal(idx: Local(UInt32(length))) != .undefined { return .undefined }
-                continue
+                // Direct locals access — same rationale as isDefined1 above.
+                switch context.locals[Local(UInt32(length))] {
+                case nil, .some(.undefined): continue
+                default: return .undefined
+                }
             case Int(Opcode.resetLocal1.rawValue):
                 context.locals[Local(UInt32(length))] = nil
                 continue
             case Int(Opcode.resultSetAdd1.rawValue):
-                let val = context.resolveLocal(idx: Local(UInt32(length)))
-                if val == .undefined { return .undefined }
-                context.results.insert(val)
-                continue
+                // Direct locals access — same rationale as isDefined1 above.
+                switch context.locals[Local(UInt32(length))] {
+                case nil, .some(.undefined): return .undefined
+                case .some(let v):
+                    context.results.insert(v)
+                    continue
+                }
             case Int(Opcode.returnLocal1.rawValue):
                 return BlockResult(functionReturnValue: context.resolveLocal(idx: Local(UInt32(length))))
             case Int(Opcode.break1.rawValue):
@@ -329,7 +340,10 @@ internal final class VMContext {
     /// Resolve a local variable.
     /// `nil` and `.undefined` in the locals array are equivalent — both represent an unbound
     /// variable.  All reads must go through this function; direct `locals[idx]` access is only
-    /// permitted for writes (assignment, CoW nil-before-rebind, resetLocal).
+    /// permitted for writes (assignment, CoW nil-before-rebind, resetLocal) and in the compact
+    /// opcode hot path (isDefined1, isUndefined1, resultSetAdd1), where a direct switch on the
+    /// raw Optional handles nil and .some(.undefined) in one step without nil-coalescing.
+    /// Wrapping that pattern in a helper function (even @inline(__always)) degrades codegen.
     @inline(__always)
     func resolveLocal(idx: Local) -> AST.RegoValue {
         return locals[idx] ?? .undefined


### PR DESCRIPTION
This allows the compiler better inline than with the synthesized (non)equal functions. Applied to isDefined1, isUndefined1, resultSetAdd1 compact opcodes in executeBlock, execAssignVarOnce, execCall, and execCallDynamic.

Constant improvements throughout the benchmarks, from 3-4% up to 8% with array iter large. No regressions.