### PR TITLE
perf: Add a number-number fast path to RegoValue.compare.

### DIFF
--- a/Sources/AST/RegoValue+Comparable.swift
+++ b/Sources/AST/RegoValue+Comparable.swift
@@ -91,6 +91,21 @@ extension RegoValue: Comparable {
     }
 
     public static func compare(_ lhs: RegoValue, _ rhs: RegoValue) -> ComparisonResult {
+        // Fast path: number–number comparison using a single NSDecimalCompare call.
+        // The generic path calls `<` twice (orderedAscending check, then orderedDescending),
+        // invoking NSDecimalCompare twice for decimal values. This fast path does it once.
+        if case .number(let lNum) = lhs, case .number(let rNum) = rhs {
+            switch (lNum.storage, rNum.storage) {
+            case (.int(let l), .int(let r)):
+                if l < r { return .orderedAscending }
+                if l > r { return .orderedDescending }
+                return .orderedSame
+            default:
+                var lDec = lNum.decimalValue
+                var rDec = rNum.decimalValue
+                return NSDecimalCompare(&lDec, &rDec)
+            }
+        }
         if lhs < rhs {
             return .orderedAscending
         } else if lhs > rhs {


### PR DESCRIPTION
Add a number-number fast path to RegoValue.compare that calls NSDecimalCompare exactly once, eliminating the double evaluation (lhs < rhs then lhs > rhs).

This eliminates 3% of the allocations from the NumericLiterals benchmark.

