### PR TITLE
perf: Replace Function.path [String] with pre-joined path String

### DIFF
--- a/Sources/Bytecode/Policy.swift
+++ b/Sources/Bytecode/Policy.swift
@@ -128,7 +128,9 @@ public struct Policy: Sendable {
 /// Bytecode function metadata
 public struct Function: Sendable {
     public let name: String
-    public let path: [String]
+    /// Function path as a dot-joined string (e.g. "benchmark.iteration"), computed once at
+    /// init time. Used by execCallDynamic for function lookup.
+    public let path: String
     public let params: [Local]
     public let returnVar: Local
     public let maxLocal: Int
@@ -148,7 +150,7 @@ public struct Function: Sendable {
         blocks: [(offset: Int, size: Int)]
     ) {
         self.name = name
-        self.path = path
+        self.path = path.joined(separator: ".")
         self.params = params
         self.returnVar = returnVar
         self.maxLocal = maxLocal

--- a/Sources/Rego/VM+Instructions.swift
+++ b/Sources/Rego/VM+Instructions.swift
@@ -275,10 +275,8 @@ extension VM {
             args.append(argValue)
         }
 
-        // Find function by path (joined with ".").
-        // Both the callDynamic path segments and the Function.path array use the same naming
-        // convention (no "data" prefix), so joining with "." gives a directly comparable key.
-        guard let function = policy.functions.first(where: { $0.path.joined(separator: ".") == funcName }) else {
+        // Find function by path.
+        guard let function = policy.functions.first(where: { $0.path == funcName }) else {
             return failWithUndefinedBytecode(context: context)
         }
 


### PR DESCRIPTION
Store path as a dot-joined `String` computed once at Function init time, eliminating the `[String]` heap allocation per function and the `path.joined()` call on every `execCallDynamic` comparison.

This delivers 1–3% instruction reduction on dynamic call benchmarks.
