### PR TITLE
perf: Pre-resolve builtins by string table index at query prepare time

### DIFF
--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -102,6 +102,8 @@ extension OPA.Engine {
         let evaluator: any Evaluator
         let store: any OPA.Store
         let builtinRegistry: BuiltinRegistry
+        /// Builtin functions pre-resolved by string table index for each policy.
+        let builtins: [[Builtin?]]
 
         /// Returns the result of evaluating the prepared query against the given input.
         ///
@@ -123,8 +125,7 @@ extension OPA.Engine {
                 tracer: tracer,
                 strictBuiltins: strictBuiltins
             )
-
-            return try await self.evaluator.evaluate(withContext: ctx)
+            return try await self.evaluator.evaluate(withContext: ctx, builtins: self.builtins)
         }
     }
 
@@ -316,7 +317,8 @@ extension OPA.Engine {
             query: query,
             evaluator: evaluator,
             store: self.store,
-            builtinRegistry: mergedBuiltinRegistry
+            builtinRegistry: mergedBuiltinRegistry,
+            builtins: evaluator.policies.map { policy in policy.strings.map { mergedBuiltinRegistry[$0] } }
         )
     }
 

--- a/Sources/Rego/Evaluator.swift
+++ b/Sources/Rego/Evaluator.swift
@@ -3,9 +3,8 @@ import AST
 import Foundation
 
 protocol Evaluator: Sendable {
-    func evaluate(withContext ctx: EvaluationContext) async throws -> ResultSet
+    func evaluate(withContext ctx: EvaluationContext, builtins: [[Builtin?]]) async throws -> ResultSet
 }
-
 /// EvaluationContext is the common evaluation context that is passed to the common Engine.
 internal struct EvaluationContext {
     public let query: String

--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -164,13 +164,13 @@ internal struct IREvaluator {
 }
 
 extension IREvaluator: Evaluator {
-    func evaluate(withContext ctx: EvaluationContext) async throws -> ResultSet {
+    func evaluate(withContext ctx: EvaluationContext, builtins: [[Builtin?]]) async throws -> ResultSet {
         let entrypoint = try queryToEntryPoint(ctx.query)
         guard let hit = planIndex[entrypoint] else {
             throw RegoError(code: .unknownQuery, message: "query not found in plan: \(ctx.query)")
         }
         let vm = VM(policy: policies[hit.policyIdx])
-        return try await vm.executePlan(withContext: ctx, planIndex: hit.planIdx)
+        return try await vm.executePlan(withContext: ctx, planIndex: hit.planIdx, builtins: builtins[hit.policyIdx])
     }
 }
 

--- a/Sources/Rego/VM+Instructions.swift
+++ b/Sources/Rego/VM+Instructions.swift
@@ -184,16 +184,7 @@ extension VM {
             }
 
             let stringIndex = Int(encodedFuncIndex & 0x7FFF_FFFF)
-            let builtinName = policy.strings[stringIndex]
 
-            // Look up builtin in registry using subscript
-            guard let builtin = context.evaluationContext.builtins[builtinName] else {
-                // Builtin not found - fail with undefined
-                return failWithUndefinedBytecode(context: context)
-            }
-
-            // Use the fast-path init; builtinsRand is guaranteed non-nil here
-            // because we only reach this branch when the policy has builtins.
             let builtinContext = BuiltinContext(
                 tracer: context.evaluationContext.tracer,
                 cache: context.evaluationContext.builtinsCache,
@@ -201,8 +192,12 @@ extension VM {
                 rand: context.builtinsRand
             )
 
-            // Invoke builtin
             let returnValue: AST.RegoValue
+            guard stringIndex < context.builtins.count,
+                let builtin = context.builtins[stringIndex]
+            else {
+                return failWithUndefinedBytecode(context: context)
+            }
             do {
                 returnValue = try await builtin(builtinContext, args)
             } catch {

--- a/Sources/Rego/VM.swift
+++ b/Sources/Rego/VM.swift
@@ -16,7 +16,8 @@ extension VM {
     /// Execute a bytecode plan
     func executePlan(
         withContext ctx: EvaluationContext,
-        planIndex: Int
+        planIndex: Int,
+        builtins: [Builtin?] = []
     ) async throws -> ResultSet {
         guard planIndex < policy.plans.count else {
             throw Error.invalidPayloadLength
@@ -28,7 +29,8 @@ extension VM {
             evaluationContext: ctx,
             policy: policy,
             planMaxLocal: plan.maxLocal,
-            data: data
+            data: data,
+            builtins: builtins
         )
 
         for block in plan.blocks {
@@ -339,9 +341,16 @@ internal final class VMContext {
     // Pool for reusing args arrays
     private var argsPool: [[AST.RegoValue]] = []
 
-    init(evaluationContext: EvaluationContext, policy: Policy, planMaxLocal: Int, data: AST.RegoValue) {
+    // Builtin functions pre-resolved by string table index at query prepare time.
+    let builtins: [Builtin?]
+
+    init(
+        evaluationContext: EvaluationContext, policy: Policy, planMaxLocal: Int,
+        data: AST.RegoValue, builtins: [Builtin?] = []
+    ) {
         self.evaluationContext = evaluationContext
         self.policy = policy
+        self.builtins = builtins
         self.tracingEnabled = evaluationContext.tracer != nil
         self.results = ResultSet.empty
 

--- a/Tests/RegoTests/IREvaluatorValidationTests.swift
+++ b/Tests/RegoTests/IREvaluatorValidationTests.swift
@@ -138,8 +138,10 @@ struct IREvaluatorValidationTests {
         // than throwing unknownQuery. A name from neither source must throw.
         let store = OPA.InMemoryStore(initialData: .object(["data": .object([:])]))
         func evaluate(_ query: String) async throws -> ResultSet {
-            try await evaluator.evaluate(
-                withContext: EvaluationContext(query: query, input: .object([:]), store: store))
+            let builtins = evaluator.policies.map { _ in [Builtin?]() }
+            return try await evaluator.evaluate(
+                withContext: EvaluationContext(query: query, input: .object([:]), store: store),
+                builtins: builtins)
         }
 
         #expect(try await evaluate("data.bundle.allow") == ResultSet.empty)


### PR DESCRIPTION
Replace the per-call `[String: Builtin]` hash lookup in `execCall` with an array subscript keyed by string table index. The index is built once in `PreparedQuery` where policies and the builtin registry first meet, and passed through to VM on each evaluate call.

This results in 2–7% fewer instructions and 5–20% wall clock improvement across all builtin-heavy benchmarks. No regressions.