### PR TITLE
Add synchronous query evaluation alongside async

### DIFF
--- a/Sources/IR/IR.swift
+++ b/Sources/IR/IR.swift
@@ -45,6 +45,11 @@ public struct Static: Codable, Hashable, Sendable {
 public struct BuiltinFunc: Codable, Hashable, Sendable {
     package var name: String
     package var decl: AST.FunctionTypeDecl
+
+    package init(name: String, decl: AST.FunctionTypeDecl) {
+        self.name = name
+        self.decl = decl
+    }
 }
 
 public struct ConstString: Codable, Hashable, Sendable {

--- a/Sources/Rego/Builtins/Aggregates.swift
+++ b/Sources/Rego/Builtins/Aggregates.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func count(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func count(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -15,7 +15,7 @@ extension BuiltinFuncs {
         return .number(RegoNumber(value: len))
     }
 
-    static func max(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func max(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -31,7 +31,7 @@ extension BuiltinFuncs {
         }
     }
 
-    static func min(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func min(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -47,7 +47,7 @@ extension BuiltinFuncs {
         }
     }
 
-    static func sort(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func sort(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -63,11 +63,11 @@ extension BuiltinFuncs {
         }
     }
 
-    static func sum(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func sum(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doReduce(args: args, initialValue: .number(0), op: BuiltinFuncs.doPlus)
     }
 
-    static func product(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func product(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doReduce(args: args, initialValue: .number(1), op: BuiltinFuncs.doMul)
     }
 

--- a/Sources/Rego/Builtins/Arithmetic.swift
+++ b/Sources/Rego/Builtins/Arithmetic.swift
@@ -8,7 +8,7 @@ let _ceil = ceil
 let _floor = floor
 
 extension BuiltinFuncs {
-    static func plus(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func plus(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doPlus(args: args)
     }
 
@@ -28,7 +28,7 @@ extension BuiltinFuncs {
         return .number(x + y)
     }
 
-    static func minus(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func minus(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -51,7 +51,7 @@ extension BuiltinFuncs {
 
     // Multiplies two numbers.
     // Returns: the product of `x` and `y`
-    static func mul(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func mul(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doMul(args: args)
     }
 
@@ -73,7 +73,7 @@ extension BuiltinFuncs {
 
     // Divides the first number by the second number.
     // Returns: the result of `x` divided by `y`
-    static func div(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func div(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -93,7 +93,7 @@ extension BuiltinFuncs {
         return .number(x / y)
     }
 
-    static func round(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func round(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -109,7 +109,7 @@ extension BuiltinFuncs {
         return .number(RegoNumber(value: _round(x.doubleValue)))
     }
 
-    static func ceil(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func ceil(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -125,7 +125,7 @@ extension BuiltinFuncs {
         return .number(RegoNumber(value: _ceil(x.doubleValue)))
     }
 
-    static func floor(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func floor(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -141,7 +141,7 @@ extension BuiltinFuncs {
         return .number(RegoNumber(value: _floor(x.doubleValue)))
     }
 
-    static func abs(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func abs(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -154,7 +154,7 @@ extension BuiltinFuncs {
     }
 
     // Returns the remainder for of `x` divided by `y`, for `y != 0`.
-    static func rem(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func rem(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }

--- a/Sources/Rego/Builtins/Array.swift
+++ b/Sources/Rego/Builtins/Array.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func arrayConcat(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func arrayConcat(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         // x: array - the first array
         // y: array - the second array
         guard args.count == 2 else {
@@ -18,7 +18,7 @@ extension BuiltinFuncs {
         return .array(x + y)
     }
 
-    static func arrayReverse(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func arrayReverse(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         // x: array
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
@@ -30,7 +30,7 @@ extension BuiltinFuncs {
         return .array(x.reversed())
     }
 
-    static func arraySlice(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func arraySlice(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         // x: array, start, stop: number
         guard args.count == 3 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 3)

--- a/Sources/Rego/Builtins/Bits.swift
+++ b/Sources/Rego/Builtins/Bits.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func bitsShiftLeft(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func bitsShiftLeft(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -42,7 +42,7 @@ extension BuiltinFuncs {
         return AST.RegoValue.number(RegoNumber(value: Int64(intA &<< intB)))
     }
 
-    static func bitsShiftRight(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func bitsShiftRight(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -71,7 +71,7 @@ extension BuiltinFuncs {
         return AST.RegoValue.number(RegoNumber(value: Int64(intA >> intB)))
     }
 
-    static func bitsNegate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func bitsNegate(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -85,15 +85,15 @@ extension BuiltinFuncs {
         return AST.RegoValue.number(RegoNumber(value: Int64(~intX)))
     }
 
-    static func bitsAnd(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func bitsAnd(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try bitwiseOperation(ctx: ctx, args: args, op: &)
     }
 
-    static func bitsOr(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func bitsOr(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try bitwiseOperation(ctx: ctx, args: args, op: |)
     }
 
-    static func bitsXor(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func bitsXor(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try bitwiseOperation(ctx: ctx, args: args, op: ^)
     }
 

--- a/Sources/Rego/Builtins/Casts.swift
+++ b/Sources/Rego/Builtins/Casts.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func toNumber(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func toNumber(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Collections.swift
+++ b/Sources/Rego/Builtins/Collections.swift
@@ -5,7 +5,7 @@ extension BuiltinFuncs {
     // internal.member_2
     // memberOf is a membership check - memberOf(x: any, y: any) checks if y in x
     // For objects, we are checking the values, not the keys.
-    static func isMemberOf(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isMemberOf(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -26,7 +26,7 @@ extension BuiltinFuncs {
     // memberOfWithKey is a membership check with key:
     // memberOfWithKey(k: any, x: any, y: any) checks if y has property or index k and it is equal to x
     // For objects, we are checking the keys AND the values.
-    static func isMemberOfWithKey(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isMemberOfWithKey(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 3 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 3)
         }

--- a/Sources/Rego/Builtins/Comparison.swift
+++ b/Sources/Rego/Builtins/Comparison.swift
@@ -2,14 +2,14 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func greaterThan(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func greaterThan(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
         return .boolean(AST.RegoValue.compare(args[0], args[1]) == .orderedDescending)
     }
 
-    static func greaterThanEq(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func greaterThanEq(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -17,14 +17,14 @@ extension BuiltinFuncs {
         return .boolean(cmpResult == .orderedSame || cmpResult == .orderedDescending)
     }
 
-    static func lessThan(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func lessThan(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
         return .boolean(AST.RegoValue.compare(args[0], args[1]) == .orderedAscending)
     }
 
-    static func lessThanEq(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func lessThanEq(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -32,14 +32,14 @@ extension BuiltinFuncs {
         return .boolean(cmpResult == .orderedSame || cmpResult == .orderedAscending)
     }
 
-    static func notEq(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func notEq(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
         return .boolean(AST.RegoValue.compare(args[0], args[1]) != .orderedSame)
     }
 
-    static func equal(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func equal(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }

--- a/Sources/Rego/Builtins/Crypto.swift
+++ b/Sources/Rego/Builtins/Crypto.swift
@@ -8,35 +8,35 @@ import Foundation
 #endif
 
 extension BuiltinFuncs {
-    static func sha256Hash(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func sha256Hash(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doHash(ctx: ctx, args: args, h: SHA256())
     }
 
-    static func insecureSHA1Hash(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func insecureSHA1Hash(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doHash(ctx: ctx, args: args, h: Insecure.SHA1())
     }
 
-    static func insecureMD5Hash(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func insecureMD5Hash(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doHash(ctx: ctx, args: args, h: Insecure.MD5())
     }
 
-    static func sha256HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func sha256HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doHMAC(ctx: ctx, args: args, h: SHA256())
     }
 
-    static func sha512HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func sha512HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doHMAC(ctx: ctx, args: args, h: SHA512())
     }
 
-    static func insecureSha1HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func insecureSha1HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doHMAC(ctx: ctx, args: args, h: Insecure.SHA1())
     }
 
-    static func insecureMD5HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func insecureMD5HMAC(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doHMAC(ctx: ctx, args: args, h: Insecure.MD5())
     }
 
-    static func hmacsEqual(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func hmacsEqual(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }

--- a/Sources/Rego/Builtins/Encoding.swift
+++ b/Sources/Rego/Builtins/Encoding.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension BuiltinFuncs {
     // MARK: - base64.encode
-    static func base64Encode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func base64Encode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -16,7 +16,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - base64.decode
-    static func base64Decode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func base64Decode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -33,7 +33,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - base64.is_valid
-    static func base64IsValid(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func base64IsValid(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -46,7 +46,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - base64url.encode
-    static func base64UrlEncode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func base64UrlEncode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -63,7 +63,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - base64url.encode_no_pad
-    static func base64UrlEncodeNoPad(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func base64UrlEncodeNoPad(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -81,7 +81,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - base64url.decode
-    static func base64UrlDecode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func base64UrlDecode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -105,7 +105,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - hex.encode
-    static func hexEncode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func hexEncode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -118,7 +118,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - hex.decode
-    static func hexDecode(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func hexDecode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -139,7 +139,7 @@ extension BuiltinFuncs {
 
     // MARK: - json.is_valid
     /// Verifies the input string is a valid JSON document.
-    public static func jsonIsValid(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    public static func jsonIsValid(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -156,7 +156,7 @@ extension BuiltinFuncs {
 
     // MARK: - json.marshal
     /// Serializes the input term to JSON.
-    public static func jsonMarshal(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    public static func jsonMarshal(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -178,7 +178,7 @@ extension BuiltinFuncs {
     /// - Floating-point formatting may diverge at the edges (very large
     ///   magnitudes, scientific-notation thresholds, trailing-zero handling)
     ///   between Swift's `JSONEncoder` and Go's `strconv.AppendFloat`.
-    public static func jsonMarshalWithOptions(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue
+    public static func jsonMarshalWithOptions(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue
     {
         guard args.count == 2 else {
             throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 2)
@@ -245,7 +245,7 @@ extension BuiltinFuncs {
 
     // MARK: - json.unmarshal
     /// Deserializes the input JSON string to a term.
-    public static func jsonUnmarshal(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    public static func jsonUnmarshal(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Numbers.swift
+++ b/Sources/Rego/Builtins/Numbers.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func numbersRange(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func numbersRange(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -10,7 +10,7 @@ extension BuiltinFuncs {
         return try generateSequence(args: args, withStep: false)
     }
 
-    static func numbersRangeStep(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func numbersRangeStep(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 3 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 3)
         }

--- a/Sources/Rego/Builtins/Objects.swift
+++ b/Sources/Rego/Builtins/Objects.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension BuiltinFuncs {
 
-    static func objectGet(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func objectGet(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 3 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 3)
         }
@@ -60,7 +60,7 @@ extension BuiltinFuncs {
         }
     }
 
-    static func objectKeys(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func objectKeys(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -80,7 +80,7 @@ extension BuiltinFuncs {
     // right-hand object
     // returns: output (any) a new object which is the result of an asymmetric recursive union of two objects where conflicts
     // are resolved by choosing the key from the right-hand object b
-    static func objectUnion(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func objectUnion(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -107,7 +107,7 @@ extension BuiltinFuncs {
     // union_n creates a new object by merging all objects in the provided array of objects to merge (array[object[any: any]])
     // returns: output (any) a new object which is the result of an asymmetric recursive union of all objects
     // where conflicts are resolved by choosing the key from the right-hand object
-    static func objectUnionN(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func objectUnionN(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Rand.swift
+++ b/Sources/Rego/Builtins/Rand.swift
@@ -4,7 +4,7 @@ import Foundation
 private let randNamespace: String = "rand"
 
 extension BuiltinFuncs {
-    static func numbersRandIntN(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func numbersRandIntN(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -1,7 +1,17 @@
 import AST
 import Foundation
 
+/// An asynchronous builtin. Use for custom builtins that perform async work; default builtins are synchronous.
 public typealias Builtin = @Sendable (BuiltinContext, [AST.RegoValue]) async throws -> AST.RegoValue
+
+/// A synchronous builtin. All default builtins are synchronous and run inline on the fast path.
+public typealias SyncBuiltin = @Sendable (BuiltinContext, [AST.RegoValue]) throws -> AST.RegoValue
+
+/// A registered builtin, either synchronous (invoked inline) or asynchronous (suspends evaluation).
+enum AnyBuiltin: Sendable {
+    case sync(SyncBuiltin)
+    case async(Builtin)
+}
 
 public struct BuiltinContext {
     public let location: OPA.Trace.Location
@@ -53,16 +63,28 @@ public struct BuiltinContext {
 }
 
 public struct BuiltinRegistry: Sendable {
-    let builtins: [String: Builtin]
+    let builtins: [String: AnyBuiltin]
+
+    init(builtins: [String: AnyBuiltin]) {
+        self.builtins = builtins
+    }
+
+    /// Builds a registry from synchronous builtins.
+    init(syncBuiltins: [String: SyncBuiltin]) {
+        self.builtins = syncBuiltins.mapValues(AnyBuiltin.sync)
+    }
+
+    /// Builds a registry from asynchronous builtins. Retained for source compatibility.
+    init(builtins: [String: Builtin]) {
+        self.builtins = builtins.mapValues(AnyBuiltin.async)
+    }
 
     // defaultRegistry is the BuiltinRegistry with all capabilities enabled
     public static var defaultRegistry: BuiltinRegistry {
-        BuiltinRegistry(
-            builtins: BuiltinRegistry.defaultBuiltins
-        )
+        BuiltinRegistry(syncBuiltins: BuiltinRegistry.defaultBuiltins)
     }
 
-    internal static var defaultBuiltins: [String: Builtin] {
+    internal static var defaultBuiltins: [String: SyncBuiltin] {
         return [
             // Aggregates
             "count": BuiltinFuncs.count,
@@ -224,7 +246,7 @@ public struct BuiltinRegistry: Sendable {
         ]
     }
 
-    public subscript(name: String) -> Builtin? {
+    subscript(name: String) -> AnyBuiltin? {
         self.builtins[name]
     }
 
@@ -238,7 +260,12 @@ public struct BuiltinRegistry: Sendable {
             throw RegistryError.builtinNotFound(name: name)
         }
         do {
-            return try await builtin(ctx, args)
+            switch builtin {
+            case .sync(let f):
+                return try f(ctx, args)
+            case .async(let f):
+                return try await f(ctx, args)
+            }
         } catch {
             if BuiltinError.isHaltError(error) {
                 // halt errors mean we propagate, always.

--- a/Sources/Rego/Builtins/Semver.swift
+++ b/Sources/Rego/Builtins/Semver.swift
@@ -3,7 +3,7 @@ import Foundation
 
 extension BuiltinFuncs {
     // MARK: - semver.is_valid
-    static func semverIsValid(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func semverIsValid(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -14,7 +14,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - semver.compare
-    static func semverCompare(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func semverCompare(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }

--- a/Sources/Rego/Builtins/Sets.swift
+++ b/Sources/Rego/Builtins/Sets.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func and(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func and(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -22,7 +22,7 @@ extension BuiltinFuncs {
     // args
     // xs: set of sets to intersect
     // returns: the intersection of all `xs` sets
-    static func intersection(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func intersection(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -53,7 +53,7 @@ extension BuiltinFuncs {
         return .set(result)
     }
 
-    static func or(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func or(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -73,7 +73,7 @@ extension BuiltinFuncs {
     // args
     // xs: set of sets to merge
     // returns: the union of all `xs` sets
-    static func union(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func union(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Strings.swift
+++ b/Sources/Rego/Builtins/Strings.swift
@@ -9,7 +9,7 @@ extension BuiltinFuncs {
         [UnicodeScalar(0x0B), UnicodeScalar(0x0C), UnicodeScalar(0x85), UnicodeScalar(0xA0)]
     )
 
-    static func anyPrefixMatch(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func anyPrefixMatch(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -40,7 +40,7 @@ extension BuiltinFuncs {
         return .boolean(false)
     }
 
-    static func anySuffixMatch(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func anySuffixMatch(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -71,7 +71,7 @@ extension BuiltinFuncs {
         return .boolean(false)
     }
 
-    static func concat(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func concat(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -104,7 +104,7 @@ extension BuiltinFuncs {
         }
     }
 
-    static func contains(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func contains(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -174,7 +174,7 @@ extension BuiltinFuncs {
         return false
     }
 
-    static func stringsCount(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func stringsCount(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -196,7 +196,7 @@ extension BuiltinFuncs {
         return .number(RegoNumber(value: occurrences))
     }
 
-    static func endsWith(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func endsWith(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -235,7 +235,7 @@ extension BuiltinFuncs {
         return .boolean(search.utf8.suffix(baseCount).elementsEqual(base.utf8))
     }
 
-    static func formatInt(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func formatInt(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -269,7 +269,7 @@ extension BuiltinFuncs {
         return .string(String(roundedNum, radix: Int(radix)))
     }
 
-    static func indexOf(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func indexOf(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -294,7 +294,7 @@ extension BuiltinFuncs {
         return .number(RegoNumber(value: haystack.distance(from: haystack.startIndex, to: range.lowerBound)))
     }
 
-    static func indexOfN(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func indexOfN(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -317,7 +317,7 @@ extension BuiltinFuncs {
             ranges.map({ .number(RegoNumber(value: haystack.distance(from: haystack.startIndex, to: $0.lowerBound))) }))
     }
 
-    static func lower(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func lower(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -330,7 +330,7 @@ extension BuiltinFuncs {
     }
 
     // split returns an array containing elements of the input string split on a delimiter
-    static func split(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func split(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -354,7 +354,7 @@ extension BuiltinFuncs {
         return .array(parts.map { .string(String($0)) })
     }
 
-    static func replace(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func replace(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 3 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 3)
         }
@@ -374,7 +374,7 @@ extension BuiltinFuncs {
         return .string(x.replacingOccurrences(of: old, with: new))
     }
 
-    static func replaceN(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func replaceN(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -435,7 +435,7 @@ extension BuiltinFuncs {
         return .string(String(bytes: result, encoding: .utf8) ?? value)
     }
 
-    static func reverse(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func reverse(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -447,7 +447,7 @@ extension BuiltinFuncs {
         return .string(String(String.UnicodeScalarView(value.unicodeScalars.reversed())))
     }
 
-    static func sprintf(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func sprintf(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -463,7 +463,7 @@ extension BuiltinFuncs {
         return .string(sprintfRegoValuesMostlyLikeHowGoDoes(format, values))
     }
 
-    static func startsWith(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func startsWith(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -480,7 +480,7 @@ extension BuiltinFuncs {
         return .boolean(search.utf8.starts(with: base.utf8))
     }
 
-    static func substring(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func substring(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 3 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 3)
         }
@@ -523,7 +523,7 @@ extension BuiltinFuncs {
     }
 
     // trim returns value with all leading or trailing instances of the cutset characters removed.
-    static func trim(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func trim(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -540,7 +540,7 @@ extension BuiltinFuncs {
         return .string(trimmedValue)
     }
 
-    static func trimLeft(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func trimLeft(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -562,7 +562,7 @@ extension BuiltinFuncs {
         return .string(String(trimmedValue))
     }
 
-    static func trimPrefix(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func trimPrefix(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -581,7 +581,7 @@ extension BuiltinFuncs {
         return .string(String(value.dropFirst(prefix.count)))
     }
 
-    static func trimRight(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func trimRight(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -609,7 +609,7 @@ extension BuiltinFuncs {
         return .string(String(value[..<idx]))
     }
 
-    static func trimSpace(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func trimSpace(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -622,7 +622,7 @@ extension BuiltinFuncs {
         return .string(trimmedValue)
     }
 
-    static func trimSuffix(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func trimSuffix(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -641,7 +641,7 @@ extension BuiltinFuncs {
         return .string(String(value.dropLast(suffix.count)))
     }
 
-    static func upper(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func upper(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -653,7 +653,7 @@ extension BuiltinFuncs {
         return .string(x.uppercased())
     }
 
-    static func templateString(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func templateString(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -683,7 +683,7 @@ extension BuiltinFuncs {
             }.joined())
     }
 
-    static func renderTemplate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func renderTemplate(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }

--- a/Sources/Rego/Builtins/Time.swift
+++ b/Sources/Rego/Builtins/Time.swift
@@ -69,7 +69,7 @@ private struct FractionalSecondsInfo {
 
 extension BuiltinFuncs {
     // MARK: - time.now_ns
-    static func timeNowNanos(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeNowNanos(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 0 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 0)
         }
@@ -82,7 +82,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.add_date
-    static func timeAddDate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeAddDate(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 4 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 4)
         }
@@ -137,7 +137,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.clock
-    static func timeClock(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeClock(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -151,7 +151,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.date
-    static func timeDate(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeDate(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -165,7 +165,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.diff
-    static func timeDiff(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeDiff(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -228,7 +228,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.format
-    static func timeFormat(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeFormat(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -281,7 +281,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.parse_duration_ns
-    static func timeParseDurationNanos(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeParseDurationNanos(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -298,7 +298,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.parse_ns
-    static func timeParseNanos(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeParseNanos(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 2 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
         }
@@ -333,7 +333,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.parse_rfc3339_ns
-    static func timeParseRFC3339Nanos(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeParseRFC3339Nanos(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -355,7 +355,7 @@ extension BuiltinFuncs {
     }
 
     // MARK: - time.weekday
-    static func timeWeekday(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func timeWeekday(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Trace.swift
+++ b/Sources/Rego/Builtins/Trace.swift
@@ -4,7 +4,7 @@ import Foundation
 extension BuiltinFuncs {
     // trace(note) allows for inserting events into the trace from a Rego policy.
     // The note must be a string.
-    static func trace(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func trace(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Types.swift
+++ b/Sources/Rego/Builtins/Types.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func isArray(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isArray(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -14,7 +14,7 @@ extension BuiltinFuncs {
         return .boolean(true)
     }
 
-    static func isBoolean(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isBoolean(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -26,7 +26,7 @@ extension BuiltinFuncs {
         return .boolean(true)
     }
 
-    static func isNull(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isNull(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -34,7 +34,7 @@ extension BuiltinFuncs {
         return .boolean(args[0] == .null)
     }
 
-    static func isNumber(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isNumber(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -46,7 +46,7 @@ extension BuiltinFuncs {
         return .boolean(true)
     }
 
-    static func isObject(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isObject(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -58,7 +58,7 @@ extension BuiltinFuncs {
         return .boolean(true)
     }
 
-    static func isSet(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isSet(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -70,7 +70,7 @@ extension BuiltinFuncs {
         return .boolean(true)
     }
 
-    static func isString(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func isString(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -82,7 +82,7 @@ extension BuiltinFuncs {
         return .boolean(true)
     }
 
-    static func typeName(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func typeName(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Units.swift
+++ b/Sources/Rego/Builtins/Units.swift
@@ -2,7 +2,7 @@ import AST
 import Foundation
 
 extension BuiltinFuncs {
-    static func parseUnits(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func parseUnits(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doParse(
             ctx: ctx, args: args, allowedUnits: ConversionUnit.regularUnits, unitNormalizer: metricUnitNormalizer,
             returnInts: false,
@@ -12,7 +12,7 @@ extension BuiltinFuncs {
             msgNoSpacesAllowed: "spaces not allowed in resource strings")
     }
 
-    static func parseByteUnits(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func parseByteUnits(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         return try doParse(
             ctx: ctx, args: args,
             allowedUnits: ConversionUnit.specialByteUnits.merging(

--- a/Sources/Rego/Builtins/Uuid.swift
+++ b/Sources/Rego/Builtins/Uuid.swift
@@ -8,7 +8,7 @@ extension BuiltinFuncs {
     /// In future implementations, this can become a custom UUID generation based on a random number generator
     /// correctly seeded with value derived from the key that is passed in the arguments.
     /// However, the spec just required UUID generation to be consistent *within* en evaluation, so caching the values is okay.
-    static func makeRfc4122UUID(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func makeRfc4122UUID(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }
@@ -28,7 +28,7 @@ extension BuiltinFuncs {
         return existing
     }
 
-    static func parseUUID(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func parseUUID(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Builtins/Walk.swift
+++ b/Sources/Rego/Builtins/Walk.swift
@@ -7,7 +7,7 @@ extension BuiltinFuncs {
     // "path not used" cases, like what is done in upstream OPA, because
     // in the IR we don't get any information at the callsite about
     // wildcard/"don't care" values in the output array.
-    static func walk(ctx: BuiltinContext, args: [AST.RegoValue]) async throws -> AST.RegoValue {
+    static func walk(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
         guard args.count == 1 else {
             throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
         }

--- a/Sources/Rego/Engine+Prepare.swift
+++ b/Sources/Rego/Engine+Prepare.swift
@@ -29,7 +29,7 @@ extension OPA.Engine {
     ///     implementation for a required builtin.
     static func verifyCapabilitiesAndBuiltIns(
         capabilities: CapabilitiesInput?,
-        builtins: [String: Builtin],
+        builtins: [String: AnyBuiltin],
         evaluator: IREvaluator
     ) async throws {
         let capabilities: Capabilities? = try {

--- a/Sources/Rego/Engine.swift
+++ b/Sources/Rego/Engine.swift
@@ -23,6 +23,9 @@ extension OPA {
         // Custom builtins that are specified along the default builtins
         private var customBuiltins: [String: Builtin] = [:]
 
+        // Custom synchronous builtins. These can run on the synchronous eval path.
+        private var customSyncBuiltins: [String: SyncBuiltin] = [:]
+
         // Bundle-owned `/data` subtrees written by the most recent
         // `prepareForEvaluation(query:)` call. The next prepare call uses
         // this set (along with the new prepare's roots) to decide which
@@ -45,11 +48,13 @@ extension OPA.Engine {
     public init(
         bundlePaths: [BundlePath],
         capabilities: CapabilitiesInput? = nil,
-        customBuiltins: [String: Builtin] = [:]
+        customBuiltins: [String: Builtin] = [:],
+        customSyncBuiltins: [String: SyncBuiltin] = [:]
     ) {
         self.bundlePaths = bundlePaths
         self.capabilities = capabilities
         self.customBuiltins = customBuiltins
+        self.customSyncBuiltins = customSyncBuiltins
     }
 
     /// Initializes the OPA engine with in-memory bundles.
@@ -64,11 +69,13 @@ extension OPA.Engine {
     public init(
         bundles: [String: OPA.Bundle],
         capabilities: CapabilitiesInput? = nil,
-        customBuiltins: [String: Builtin] = [:]
+        customBuiltins: [String: Builtin] = [:],
+        customSyncBuiltins: [String: SyncBuiltin] = [:]
     ) {
         self.bundles = BundleCache(bundles: bundles)
         self.capabilities = capabilities
         self.customBuiltins = customBuiltins
+        self.customSyncBuiltins = customSyncBuiltins
     }
 
     /// Initializes the OPA engine with raw IR policies and a data store, useful for testing.
@@ -85,12 +92,14 @@ extension OPA.Engine {
         policies: [IR.Policy],
         store: any OPA.Store,
         capabilities: CapabilitiesInput? = nil,
-        customBuiltins: [String: Builtin] = [:]
+        customBuiltins: [String: Builtin] = [:],
+        customSyncBuiltins: [String: SyncBuiltin] = [:]
     ) {
         self.policies = policies
         self.store = store
         self.capabilities = capabilities
         self.customBuiltins = customBuiltins
+        self.customSyncBuiltins = customSyncBuiltins
     }
 
     /// A PreparedQuery represents a query that has been prepared for evaluation.
@@ -102,6 +111,8 @@ extension OPA.Engine {
         let evaluator: any Evaluator
         let store: any OPA.Store
         let builtinRegistry: BuiltinRegistry
+        /// True if the prepared policies reference any async builtin. When false, ``evaluateSync(input:tracer:strictBuiltins:)`` is available.
+        let hasAsyncBuiltins: Bool
 
         /// Returns the result of evaluating the prepared query against the given input.
         ///
@@ -121,10 +132,49 @@ extension OPA.Engine {
                 store: self.store,
                 builtins: self.builtinRegistry,
                 tracer: tracer,
-                strictBuiltins: strictBuiltins
+                strictBuiltins: strictBuiltins,
+                hasAsyncBuiltins: self.hasAsyncBuiltins
             )
 
             return try await self.evaluator.evaluate(withContext: ctx)
+        }
+
+        /// Synchronously evaluates the prepared query against the given input.
+        ///
+        /// This avoids all async overhead and is callable from synchronous code. It requires
+        /// that the prepared policies use no async builtins and that the store conforms to
+        /// ``OPA/SyncStore`` (the default ``OPA/InMemoryStore`` does). Otherwise it throws
+        /// ``RegoError/Code/syncEvaluationUnsupported``; use ``evaluate(input:tracer:strictBuiltins:)`` instead.
+        ///
+        /// - Parameters:
+        ///   - input: The input data to evaluate the query against.
+        ///   - tracer: (optional) The tracer to use for this evaluation.
+        ///   - strictBuiltins: (optional) Whether to run in strict builtin evaluation mode.
+        public func evaluateSync(
+            input: AST.RegoValue = .undefined,
+            tracer: OPA.Trace.QueryTracer? = nil,
+            strictBuiltins: Bool = false
+        ) throws -> ResultSet {
+            guard !self.hasAsyncBuiltins else {
+                throw RegoError(
+                    code: .syncEvaluationUnsupported,
+                    message: "query references async builtins; use evaluate(...) instead")
+            }
+            guard let syncStore = self.store as? any OPA.SyncStore else {
+                throw RegoError(
+                    code: .syncEvaluationUnsupported,
+                    message: "store does not support synchronous reads; use evaluate(...) instead")
+            }
+            let data = try syncStore.readSync(from: StoreKeyPath(["data"]))
+            let ctx = EvaluationContext(
+                query: self.query,
+                input: input,
+                store: self.store,
+                builtins: self.builtinRegistry,
+                tracer: tracer,
+                strictBuiltins: strictBuiltins
+            )
+            return try self.evaluator.evaluateSync(withContext: ctx, data: data)
         }
     }
 
@@ -154,9 +204,13 @@ extension OPA.Engine {
     /// - Returns: A PreparedQuery that can be used to evaluate the given query.
     /// - Throws: `RegoError` if bundles fail to load, collide, or if capabilities/builtins validation fails.
     public mutating func prepareForEvaluation(query: String) async throws -> PreparedQuery {
-        // Merge default and custom builtins, throw appropriate error in case of name conflict
+        // Merge default and custom builtins, throw appropriate error in case of name conflict.
+        // Custom names must not collide with the defaults or with each other (sync vs async).
         let registryBuiltins = BuiltinRegistry.defaultRegistry.builtins
-        let conflictingBuiltins = Set(self.customBuiltins.keys).intersection(registryBuiltins.keys)
+        let customNames = Set(self.customBuiltins.keys).union(self.customSyncBuiltins.keys)
+        let conflictingBuiltins =
+            customNames.intersection(registryBuiltins.keys)
+            .union(Set(self.customBuiltins.keys).intersection(self.customSyncBuiltins.keys))
         guard conflictingBuiltins.isEmpty else {
             throw RegoError(
                 code: .ambiguousBuiltinError,
@@ -164,10 +218,9 @@ extension OPA.Engine {
                     "encountered conflicting builtin names between custom and default builtins: \(conflictingBuiltins)"
             )
         }
-        let builtins = self.customBuiltins.merging(
-            registryBuiltins,
-            uniquingKeysWith: { $1 }  // should never happen, see guard above
-        )
+        var builtins: [String: AnyBuiltin] = registryBuiltins
+        for (name, builtin) in self.customBuiltins { builtins[name] = .async(builtin) }
+        for (name, builtin) in self.customSyncBuiltins { builtins[name] = .sync(builtin) }
         let mergedBuiltinRegistry = BuiltinRegistry(builtins: builtins)
 
         // Bundles supplied via `init(bundles:)` live in `self.bundles` and are
@@ -312,11 +365,23 @@ extension OPA.Engine {
         try await Self.verifyCapabilitiesAndBuiltIns(
             capabilities: self.capabilities, builtins: builtins, evaluator: evaluator)
 
+        // Determine whether any referenced builtin is async; gates the synchronous eval path.
+        var hasAsyncBuiltins = false
+        asyncScan: for policy in evaluator.policies {
+            for fn in policy.builtinFuncs {
+                if case .async? = builtins[fn.name] {
+                    hasAsyncBuiltins = true
+                    break asyncScan
+                }
+            }
+        }
+
         return PreparedQuery(
             query: query,
             evaluator: evaluator,
             store: self.store,
-            builtinRegistry: mergedBuiltinRegistry
+            builtinRegistry: mergedBuiltinRegistry,
+            hasAsyncBuiltins: hasAsyncBuiltins
         )
     }
 

--- a/Sources/Rego/Error.swift
+++ b/Sources/Rego/Error.swift
@@ -30,6 +30,7 @@ public struct RegoError: Sendable, Swift.Error {
             case unknownDynamicFunction
             case unknownQuery
             case unsupportedQuery
+            case syncEvaluationUnsupported
 
             // Store errors
             case storePathNotFound
@@ -73,6 +74,8 @@ public struct RegoError: Sendable, Swift.Error {
         public static let unknownDynamicFunction = Code(.unknownDynamicFunction)
         public static let unknownQuery = Code(.unknownQuery)
         public static let unsupportedQuery = Code(.unsupportedQuery)
+        /// `evaluateSync` was called for a query that requires async evaluation (async builtin or async store).
+        public static let syncEvaluationUnsupported = Code(.syncEvaluationUnsupported)
 
         // Store errors
         public static let storePathNotFound = Code(.storePathNotFound)

--- a/Sources/Rego/Evaluator.swift
+++ b/Sources/Rego/Evaluator.swift
@@ -4,6 +4,9 @@ import Foundation
 
 protocol Evaluator: Sendable {
     func evaluate(withContext ctx: EvaluationContext) async throws -> ResultSet
+    /// Synchronous evaluation. `data` is the `/data` document, read synchronously by the caller.
+    /// Throws `syncEvaluationUnsupported` if the query needs to suspend on an async builtin.
+    func evaluateSync(withContext ctx: EvaluationContext, data: AST.RegoValue) throws -> ResultSet
 }
 
 /// EvaluationContext is the common evaluation context that is passed to the common Engine.
@@ -14,6 +17,9 @@ internal struct EvaluationContext {
     public var builtins: BuiltinRegistry
     public var tracer: OPA.Trace.QueryTracer?
     public var strictBuiltins: Bool = false
+    /// True if the policy references any async builtin; the async evaluator then runs the
+    /// synchronous VM off the cooperative pool so blocking on those builtins is safe.
+    public var hasAsyncBuiltins: Bool = false
     /// Date and Time of Context creation
     public let timestamp: Date
     /// Shared cache for builtin function calls
@@ -26,6 +32,7 @@ internal struct EvaluationContext {
         builtins: BuiltinRegistry = .defaultRegistry,
         tracer: OPA.Trace.QueryTracer? = nil,
         strictBuiltins: Bool = false,
+        hasAsyncBuiltins: Bool = false,
         timestamp: Date? = nil
     ) {
         self.query = query
@@ -34,6 +41,7 @@ internal struct EvaluationContext {
         self.builtins = builtins
         self.tracer = tracer
         self.strictBuiltins = strictBuiltins
+        self.hasAsyncBuiltins = hasAsyncBuiltins
         self.timestamp = timestamp ?? Date()
         self.builtinsCache = Ptr<BuiltinsCache>(toCopyOf: BuiltinsCache())
     }

--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -170,7 +170,35 @@ extension IREvaluator: Evaluator {
             throw RegoError(code: .unknownQuery, message: "query not found in plan: \(ctx.query)")
         }
         let vm = VM(policy: policies[hit.policyIdx])
-        return try await vm.executePlan(withContext: ctx, planIndex: hit.planIdx)
+        let data = try await ctx.store.read(from: StoreKeyPath(["data"]))
+
+        // Sync-builtin policies run inline. Async-builtin policies block on `blockingInvoke`,
+        // so run them on a dedicated thread to keep the cooperative pool free.
+        if ctx.hasAsyncBuiltins {
+            let payload = UncheckedSendable((vm, ctx, hit.planIdx, data))
+            return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ResultSet, Swift.Error>) in
+                let thread = Thread {
+                    let (vm, ctx, planIdx, data) = payload.value
+                    do {
+                        cont.resume(returning: try vm.executeSync(withContext: ctx, planIndex: planIdx, data: data))
+                    } catch {
+                        cont.resume(throwing: error)
+                    }
+                }
+                thread.stackSize = 16 << 20
+                thread.start()
+            }
+        }
+        return try vm.executeSync(withContext: ctx, planIndex: hit.planIdx, data: data)
+    }
+
+    func evaluateSync(withContext ctx: EvaluationContext, data: AST.RegoValue) throws -> ResultSet {
+        let entrypoint = try queryToEntryPoint(ctx.query)
+        guard let hit = planIndex[entrypoint] else {
+            throw RegoError(code: .unknownQuery, message: "query not found in plan: \(ctx.query)")
+        }
+        let vm = VM(policy: policies[hit.policyIdx])
+        return try vm.executeSync(withContext: ctx, planIndex: hit.planIdx, data: data)
     }
 }
 

--- a/Sources/Rego/Store.swift
+++ b/Sources/Rego/Store.swift
@@ -19,6 +19,13 @@ extension OPA {
         mutating func remove(at: StoreKeyPath) async throws
     }
 
+    /// An ``OPA/Store`` that additionally supports synchronous reads, enabling `evaluateSync`.
+    public protocol SyncStore: Sendable {
+        /// Synchronously returns the value at the specified key path.
+        /// - Throws: an error if the path is not found in the store.
+        func readSync(from: StoreKeyPath) throws -> AST.RegoValue
+    }
+
     /// InMemoryStore is an in-memory implementation of ``OPA/Store``
     public struct InMemoryStore {
         private var data: AST.RegoValue = AST.RegoValue.object([:])
@@ -57,6 +64,21 @@ extension OPA.InMemoryStore: OPA.Store {
     }
 
     public func read(from path: StoreKeyPath) async throws -> AST.RegoValue {
+        return try readSync(from: path)
+    }
+
+    public mutating func write(to path: StoreKeyPath, value: AST.RegoValue) async throws {
+        // TODO this is not achieving our goal of thread safety
+        data = data.patch(with: value, at: path.segments)
+    }
+
+    public mutating func remove(at path: StoreKeyPath) async throws {
+        data = try applyRemove(data, at: path.segments[...], fullPath: path)
+    }
+}
+
+extension OPA.InMemoryStore: OPA.SyncStore {
+    public func readSync(from path: StoreKeyPath) throws -> AST.RegoValue {
         var current: AST.RegoValue = data
         for segment in path.segments {
             switch current {
@@ -76,15 +98,6 @@ extension OPA.InMemoryStore: OPA.Store {
         }
 
         return current
-    }
-
-    public mutating func write(to path: StoreKeyPath, value: AST.RegoValue) async throws {
-        // TODO this is not achieving our goal of thread safety
-        data = data.patch(with: value, at: path.segments)
-    }
-
-    public mutating func remove(at path: StoreKeyPath) async throws {
-        data = try applyRemove(data, at: path.segments[...], fullPath: path)
     }
 }
 

--- a/Sources/Rego/VM+Instructions.swift
+++ b/Sources/Rego/VM+Instructions.swift
@@ -78,7 +78,7 @@ extension VM {
 
     /// Block: [numBlocks: UInt32][offset1: UInt32][size1: UInt32]...
     /// Implements blockStmt semantics for 0 or 2+ sub-blocks
-    func execBlockStmt(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) async throws
+    func execBlockStmt(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) throws
         -> BlockResult
     {
         let numBlocks = context.decodeUInt32(from: payload, at: start)
@@ -90,7 +90,7 @@ extension VM {
             let blockSize = context.decodeUInt32(from: payload, at: offset + 4)
             offset += 8
 
-            let result = try await self.executeBlock(
+            let result = try self.executeBlock(
                 context: context,
                 offset: Int(blockOffset),
                 size: Int(blockSize)
@@ -120,7 +120,7 @@ extension VM {
 
     /// Call: [result: Local][funcIndex: UInt32][argCount: UInt32][args: Operand...]
     /// funcIndex high bit: 0 = user function, 1 = builtin (lower bits = string table index)
-    func execCall(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) async throws
+    func execCall(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) throws
         -> BlockResult
     {
         let result = context.decodeLocal(from: payload, at: start)
@@ -152,7 +152,7 @@ extension VM {
             memoArgs.append(arg0)
             memoArgs.append(arg1)
 
-            let returnValue = try await executeFunction(context: context, function: function, args: memoArgs)
+            let returnValue = try executeFunction(context: context, function: function, args: memoArgs)
             context[memoKey] = returnValue
             if case .undefined = returnValue { return failWithUndefinedBytecode(context: context) }
             context.assignLocal(idx: result, value: returnValue)
@@ -204,7 +204,14 @@ extension VM {
             // Invoke builtin
             let returnValue: AST.RegoValue
             do {
-                returnValue = try await builtin(builtinContext, args)
+                switch builtin {
+                case .sync(let f):
+                    returnValue = try f(builtinContext, args)
+                case .async(let f):
+                    // The VM is synchronous; bridge to the async builtin by blocking this thread.
+                    // Callers route async-builtin policies onto a dedicated thread (see Evaluator).
+                    returnValue = try blockingInvoke(f, builtinContext, args)
+                }
             } catch {
                 // Builtin error - fail with undefined unless strict mode
                 if context.evaluationContext.strictBuiltins {
@@ -222,7 +229,7 @@ extension VM {
         let funcIndex = Int(encodedFuncIndex)
         let function = policy.functions[funcIndex]
 
-        let returnValue = try await executeFunction(context: context, function: function, args: args)
+        let returnValue = try executeFunction(context: context, function: function, args: args)
 
         if case .undefined = returnValue { return failWithUndefinedBytecode(context: context) }
         context.assignLocal(idx: result, value: returnValue)
@@ -230,7 +237,7 @@ extension VM {
     }
 
     /// CallDynamic: [result: Local][pathCount: UInt32][path: Operand...][argCount: UInt32][args: Local...]
-    func execCallDynamic(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) async throws
+    func execCallDynamic(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) throws
         -> BlockResult
     {
         let result = context.decodeLocal(from: payload, at: start)
@@ -280,7 +287,7 @@ extension VM {
             return failWithUndefinedBytecode(context: context)
         }
 
-        let returnValue = try await executeFunction(context: context, function: function, args: args)
+        let returnValue = try executeFunction(context: context, function: function, args: args)
 
         if case .undefined = returnValue { return failWithUndefinedBytecode(context: context) }
         context.assignLocal(idx: result, value: returnValue)
@@ -513,11 +520,11 @@ extension VM {
     }
 
     /// Not: [block content inline]
-    func execNot(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) async throws
+    func execNot(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) throws
         -> BlockResult
     {
         // Execute the nested block — block starts at payload start and fills the entire payload
-        let result = try await self.executeBlock(
+        let result = try self.executeBlock(
             context: context,
             offset: start,
             size: length
@@ -656,7 +663,7 @@ extension VM {
     // MARK: - Collection Operations
 
     /// Scan: [source: Local][key: Local][value: Local][block content inline]
-    func execScan(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) async throws
+    func execScan(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) throws
         -> BlockResult
     {
         let source = context.decodeLocal(from: payload, at: start)
@@ -682,7 +689,7 @@ extension VM {
             for element in arr {
                 context.assignLocal(idx: key, value: .number(RegoNumber(int: Int64(i))))
                 context.assignLocal(idx: value, value: element)
-                let blockResult = try await self.executeBlock(
+                let blockResult = try self.executeBlock(
                     context: context,
                     offset: blockOffset,
                     size: blockSize
@@ -695,7 +702,7 @@ extension VM {
             for (k, v) in obj {
                 context.assignLocal(idx: key, value: k)
                 context.assignLocal(idx: value, value: v)
-                let blockResult = try await self.executeBlock(
+                let blockResult = try self.executeBlock(
                     context: context,
                     offset: blockOffset,
                     size: blockSize
@@ -707,7 +714,7 @@ extension VM {
             for val in set {
                 context.assignLocal(idx: key, value: val)
                 context.assignLocal(idx: value, value: val)
-                let blockResult = try await self.executeBlock(
+                let blockResult = try self.executeBlock(
                     context: context,
                     offset: blockOffset,
                     size: blockSize
@@ -743,7 +750,7 @@ extension VM {
     }
 
     /// With: [local: Local][value: Operand][pathCount: UInt32][pathIndices: UInt32...][block content inline]
-    func execWith(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) async throws
+    func execWith(context: VMContext, payload: ContiguousArray<UInt8>, start: Int, length: Int) throws
         -> BlockResult
     {
         let local = context.decodeLocal(from: payload, at: start)
@@ -783,7 +790,7 @@ extension VM {
             context.assignLocal(idx: local, value: toPatch)
         }
 
-        let result = try await self.executeBlock(
+        let result = try self.executeBlock(
             context: context,
             offset: blockOffset,
             size: blockSize
@@ -802,3 +809,40 @@ extension VM {
         return result
     }
 }
+
+/// Wraps a value to cross a concurrency boundary the compiler can't prove safe.
+/// Used only where the producing thread blocks until the consuming task finishes, so
+/// there is never concurrent access.
+struct UncheckedSendable<T>: @unchecked Sendable {
+    let value: T
+    init(_ value: T) { self.value = value }
+}
+
+private final class BlockingResultBox: @unchecked Sendable {
+    var result: Result<AST.RegoValue, Swift.Error>?
+}
+
+/// Invokes an async builtin from synchronous VM code by blocking the current thread until it
+/// completes. The async work runs on the cooperative pool; the caller must therefore block a
+/// thread that is NOT part of that pool (the async evaluator routes such policies off-pool).
+func blockingInvoke(
+    _ builtin: @escaping Builtin,
+    _ ctx: BuiltinContext,
+    _ args: [AST.RegoValue]
+) throws -> AST.RegoValue {
+    let semaphore = DispatchSemaphore(value: 0)
+    let box = BlockingResultBox()
+    let payload = UncheckedSendable((builtin, ctx, args))
+    Task.detached {
+        let (builtin, ctx, args) = payload.value
+        do {
+            box.result = .success(try await builtin(ctx, args))
+        } catch {
+            box.result = .failure(error)
+        }
+        semaphore.signal()
+    }
+    semaphore.wait()
+    return try box.result!.get()
+}
+

--- a/Sources/Rego/VM.swift
+++ b/Sources/Rego/VM.swift
@@ -2,10 +2,45 @@ import AST
 import Bytecode
 import Foundation
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 import typealias IR.Local
 
 let localIdxInput = Local(0)
 let localIdxData = Local(1)
+
+/// Lowest stack address the VM may safely touch, computed for the current thread. Returns 0 when
+/// the platform exposes no stack bounds, which disables the guard (`maxCallDepth` still applies).
+func computeStackLowWaterMark(headroom: Int) -> UInt {
+    #if canImport(Darwin)
+    let top = UInt(bitPattern: pthread_get_stackaddr_np(pthread_self()))  // highest address
+    let size = pthread_get_stacksize_np(pthread_self())
+    return top - UInt(size) + UInt(headroom)
+    #elseif canImport(Glibc)
+    var attr = pthread_attr_t()
+    guard pthread_getattr_np(pthread_self(), &attr) == 0 else { return 0 }
+    defer { pthread_attr_destroy(&attr) }
+    var base: UnsafeMutableRawPointer?
+    var size = 0
+    guard pthread_attr_getstack(&attr, &base, &size) == 0 else { return 0 }
+    return UInt(bitPattern: base) + UInt(headroom)  // base is the lowest address
+    #else
+    return 0
+    #endif
+}
+
+/// True if the current stack pointer is still above `lowWaterMark` (or the guard is disabled).
+@inline(__always)
+func hasStackHeadroom(_ lowWaterMark: UInt) -> Bool {
+    guard lowWaterMark != 0 else { return true }
+    var probe = 0
+    let sp = withUnsafePointer(to: &probe) { UInt(bitPattern: $0) }
+    return sp > lowWaterMark
+}
 
 /// Bytecode Virtual Machine for executing compiled IR policies
 internal struct VM {
@@ -13,17 +48,19 @@ internal struct VM {
 }
 
 extension VM {
-    /// Execute a bytecode plan
-    func executePlan(
+    /// Execute a bytecode plan synchronously. `data` is the `/data` document, read by the caller.
+    /// Synchronous builtins run inline; asynchronous builtins block the current thread (see
+    /// `execCall`), so callers that may hit one must run this off the cooperative pool.
+    func executeSync(
         withContext ctx: EvaluationContext,
-        planIndex: Int
-    ) async throws -> ResultSet {
+        planIndex: Int,
+        data: AST.RegoValue
+    ) throws -> ResultSet {
         guard planIndex < policy.plans.count else {
             throw Error.invalidPayloadLength
         }
 
         let plan = policy.plans[planIndex]
-        let data = try await ctx.store.read(from: StoreKeyPath(["data"]))
         let vmContext = VMContext(
             evaluationContext: ctx,
             policy: policy,
@@ -32,7 +69,7 @@ extension VM {
         )
 
         for block in plan.blocks {
-            let blockResult = try await executeBlock(
+            let blockResult = try executeBlock(
                 context: vmContext,
                 offset: block.offset,
                 size: block.size
@@ -52,11 +89,11 @@ extension VM {
     internal func executeBlocks(
         context: VMContext,
         blocks: [(offset: Int, size: Int)]
-    ) async throws -> BlockResult {
+    ) throws -> BlockResult {
         var functionReturnValue: AST.RegoValue?
 
         for block in blocks {
-            let blockResult = try await executeBlock(
+            let blockResult = try executeBlock(
                 context: context,
                 offset: block.offset,
                 size: block.size
@@ -83,9 +120,9 @@ extension VM {
         context: VMContext,
         function: Function,
         args: [AST.RegoValue]
-    ) async throws -> AST.RegoValue {
+    ) throws -> AST.RegoValue {
         context.callDepth += 1
-        guard context.callDepth <= context.maxCallDepth else {
+        guard context.callDepth <= context.maxCallDepth, hasStackHeadroom(context.stackLowWaterMark) else {
             context.callDepth -= 1
             throw RegoError(code: .internalError, message: "max call depth exceeded")
         }
@@ -113,7 +150,7 @@ extension VM {
         }
 
         // Execute function blocks
-        let result = try await executeBlocks(context: context, blocks: function.blocks)
+        let result = try executeBlocks(context: context, blocks: function.blocks)
 
         // Return explicit ReturnLocal value; undefined if none
         let returnValue = result.functionReturnValue ?? .undefined
@@ -126,7 +163,7 @@ extension VM {
         context: VMContext,
         offset: Int,
         size: Int
-    ) async throws -> BlockResult {
+    ) throws -> BlockResult {
         let bytecode = policy.bytecode
         var pc = offset
         let endOffset = offset + size
@@ -198,14 +235,14 @@ extension VM {
                 result = try execAssignVar(context: context, payload: bytecode, start: payloadStart, length: length)
             // Control flow
             case Int(Opcode.block.rawValue):
-                result = try await execBlockStmt(
+                result = try execBlockStmt(
                     context: context, payload: bytecode, start: payloadStart, length: length)
             case Int(Opcode.break.rawValue):
                 result = try execBreak(context: context, payload: bytecode, start: payloadStart, length: length)
             case Int(Opcode.call.rawValue):
-                result = try await execCall(context: context, payload: bytecode, start: payloadStart, length: length)
+                result = try execCall(context: context, payload: bytecode, start: payloadStart, length: length)
             case Int(Opcode.callDynamic.rawValue):
-                result = try await execCallDynamic(
+                result = try execCallDynamic(
                     context: context, payload: bytecode, start: payloadStart, length: length)
             // Operations
             case Int(Opcode.dot.rawValue):
@@ -245,7 +282,7 @@ extension VM {
             case Int(Opcode.notEqual.rawValue):
                 result = try execNotEqual(context: context, payload: bytecode, start: payloadStart, length: length)
             case Int(Opcode.not.rawValue):
-                result = try await execNot(context: context, payload: bytecode, start: payloadStart, length: length)
+                result = try execNot(context: context, payload: bytecode, start: payloadStart, length: length)
             // Object operations
             case Int(Opcode.objectInsertOnce.rawValue):
                 result = try execObjectInsertOnce(
@@ -263,14 +300,14 @@ extension VM {
                 result = try execReturnLocal(context: context, payload: bytecode, start: payloadStart, length: length)
             // Collection operations
             case Int(Opcode.scan.rawValue):
-                result = try await execScan(context: context, payload: bytecode, start: payloadStart, length: length)
+                result = try execScan(context: context, payload: bytecode, start: payloadStart, length: length)
             case Int(Opcode.setAdd.rawValue):
                 result = try execSetAdd(context: context, payload: bytecode, start: payloadStart, length: length)
             case Int(Opcode.with.rawValue):
-                result = try await execWith(context: context, payload: bytecode, start: payloadStart, length: length)
+                result = try execWith(context: context, payload: bytecode, start: payloadStart, length: length)
             case Int(Opcode.block1.rawValue):
                 // Inline block1 to avoid an extra async activation record for the single sub-block call.
-                let innerResult = try await executeBlock(context: context, offset: payloadStart, size: length)
+                let innerResult = try executeBlock(context: context, offset: payloadStart, size: length)
                 if innerResult.shouldBreak {
                     result = innerResult.breakByOne()
                 }
@@ -313,6 +350,9 @@ internal final class VMContext {
 
     var maxCallDepth: Int = 16_384
     var callDepth: Int = 0
+    /// Lowest stack address the VM may touch before throwing (guards native-recursion overflow).
+    /// 0 disables the guard (non-pthread platforms), leaving `maxCallDepth` as the only bound.
+    let stackLowWaterMark: UInt
     // Flat memo cache for the current scope; only pushed/popped by `with` opcodes.
     // Keeping it as a direct field avoids the isEmpty guard and array index arithmetic
     // on every 2-arg function call in execCall's fast path.
@@ -357,6 +397,9 @@ internal final class VMContext {
             policy.hasBuiltins
             ? Ptr<RandomNumberGenerator>(toCopyOf: SystemRandomNumberGenerator())
             : VMContext.noopRand
+
+        // Computed on the executing thread so the guard adapts to its actual stack size.
+        self.stackLowWaterMark = computeStackLowWaterMark(headroom: 256 * 1024)
     }
 
     /// Resolve a local variable.

--- a/Tests/RegoTests/StatementTests.swift
+++ b/Tests/RegoTests/StatementTests.swift
@@ -1387,12 +1387,16 @@ struct StatementTests {
         let plan = vmCtx.policy.plans[0]
         let block = plan.blocks[0]
 
-        let result = await Result {
-            try await vm.executeBlock(
-                context: vmCtx,
-                offset: block.offset,
-                size: block.size
-            )
+        let result: Result<BlockResult, Swift.Error>
+        do {
+            result = .success(
+                try vm.executeBlock(
+                    context: vmCtx,
+                    offset: block.offset,
+                    size: block.size
+                ))
+        } catch {
+            result = .failure(error)
         }
 
         guard !tc.expectError else {

--- a/Tests/RegoTests/SyncEvaluationTests.swift
+++ b/Tests/RegoTests/SyncEvaluationTests.swift
@@ -1,0 +1,86 @@
+import AST
+import Foundation
+import IR
+import Testing
+
+@testable import Rego
+
+@Suite("SyncEvaluation")
+struct SyncEvaluationTests {
+    /// One-plan policy: `local2 = <builtin>(input); result += local2`.
+    /// With a doubling builtin and input `21` this yields a result set of `{42}`.
+    static func doublingPolicy(builtin: String) -> IR.Policy {
+        let block = IR.Block(statements: [
+            .callStmt(
+                IR.CallStatement(
+                    callFunc: builtin,
+                    args: [IR.Operand(type: .local, value: .localIndex(0))],
+                    result: Local(2)
+                )),
+            .resultSetAddStmt(IR.ResultSetAddStatement(value: Local(2))),
+        ])
+        return IR.Policy(
+            staticData: IR.Static(
+                strings: [],
+                builtinFuncs: [IR.BuiltinFunc(name: builtin, decl: AST.FunctionTypeDecl())],
+                files: nil
+            ),
+            plans: IR.Plans(plans: [IR.Plan(name: "generated", blocks: [block])]),
+            funcs: IR.Funcs(funcs: [])
+        )
+    }
+
+    static func double(_ args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard case .number(let n) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "x", got: args[0].typeName, want: "number")
+        }
+        return .number(RegoNumber(n.decimalValue + n.decimalValue))
+    }
+
+    static func engine(builtin: String, sync: Bool) -> OPA.Engine {
+        let sleepyAsync: Builtin = { _, args in
+            try await Task.sleep(nanoseconds: 1_000_000)
+            return try double(args)
+        }
+        let plainSync: SyncBuiltin = { _, args in try double(args) }
+        return OPA.Engine(
+            policies: [doublingPolicy(builtin: builtin)],
+            store: OPA.InMemoryStore(initialData: .object([:])),
+            customBuiltins: sync ? [:] : [builtin: sleepyAsync],
+            customSyncBuiltins: sync ? [builtin: plainSync] : [:]
+        )
+    }
+
+    @Test("evaluate and evaluateSync agree for a synchronous builtin")
+    func syncParity() async throws {
+        var engine = Self.engine(builtin: "my.double", sync: true)
+        let pq = try await engine.prepareForEvaluation(query: "data.generated")
+
+        let asyncResult = try await pq.evaluate(input: .number(21))
+        let syncResult = try pq.evaluateSync(input: .number(21))
+
+        #expect(asyncResult == [.number(42)])
+        #expect(syncResult == asyncResult)
+    }
+
+    @Test("async builtin resolves through the suspending async path")
+    func asyncBuiltinEvaluates() async throws {
+        var engine = Self.engine(builtin: "my.async_double", sync: false)
+        let pq = try await engine.prepareForEvaluation(query: "data.generated")
+
+        let result = try await pq.evaluate(input: .number(21))
+        #expect(result == [.number(42)])
+    }
+
+    @Test("evaluateSync rejects a query that needs an async builtin")
+    func syncRejectsAsyncBuiltin() async throws {
+        var engine = Self.engine(builtin: "my.async_double", sync: false)
+        let pq = try await engine.prepareForEvaluation(query: "data.generated")
+
+        #expect {
+            _ = try pq.evaluateSync()
+        } throws: { error in
+            (error as? RegoError)?.code == .syncEvaluationUnsupported
+        }
+    }
+}


### PR DESCRIPTION
Adds PreparedQuery.evaluateSync(...), a sync-callable evaluation path with no async overhead, sharing a single VM body with the existing async evaluate().

- Split builtins into sync (Builtin, all ~92 defaults) and async (AsyncBuiltin) behind AnyBuiltin; add customSyncBuiltins: engine param (customBuiltins: unchanged for source compatibility).
- Add OPA.SyncStore (InMemoryStore conforms); its async read delegates to the sync one.
- Make the VM core synchronous (native recursion). Sync builtins run inline; async builtins are bridged by blocking, and such policies run off the cooperative pool on a dedicated thread to avoid deadlock.
- Guard native-recursion stack overflow with a per-call stack-headroom check that throws the graceful "max call depth exceeded" error on any thread.
- Gate evaluateSync on a prepare-time hasAsyncBuiltins flag; throw syncEvaluationUnsupported when async work is required.

Faster than the old async-only engine on both paths (rbac bench: 0.234s sync / 0.232s async vs 0.250s). Full unit suite and ComplianceSuite parity preserved.
