### PR TITLE
IREvaluator: Apply SyncSafePatcher to user-supplied IR policies

### DIFF
--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -122,7 +122,12 @@ internal struct IREvaluator {
             for plan in p.plans?.plans ?? [] {
                 recordOwner(planName: plan.name, owner: .user(i))
             }
-            compiled.append(try Converter.convert(p))
+            let rawPolicy = try Converter.convert(p)
+            compiled.append(
+                optimizeAsync
+                    ? SyncSafePatcher.patch(policy: rawPolicy, builtins: builtinRegistry)
+                    : rawPolicy
+            )
         }
 
         // Ensure all plan names (raw user policies + bundle policies) are unique.


### PR DESCRIPTION
### What code changed, and why?
`IREvaluator.init` ran the sync-safety analyzer on bundle-derived policies but skipped user-supplied raw IR policies, leaving every user-policy plan with `syncSafe = false`. Calling the sync `PreparedQuery.evaluate` on those plans then unconditionally threw `requiresAsyncEvaluation`, even when the plan only called sync builtins.

This was visible in the compliance suite: `runTestSync` constructs the engine with `OPA.Engine.init`, so every `testComplianceSync` case failed with `requires async evaluation`, regardless of which builtins the policy used.
Unit tests that prepare engines from bundles (e.g. `testValidEvaluationsSync`) were unaffected because the bundles path
already runs the patcher.

The fix here just mirrors the bundles-loop patcher invocation in the user-policies loop, gated on the same optimizeAsync flag.

### Definition of done
Compliance tests for fully implemented builtins now pass in both sync and async forms

### How to test
`OPA_COMPLIANCE_TESTS=aggregates make test-compliance` fully succeeds

### Related Resources
Fixes: #167
