### PR TITLE
chore: Fix paths in release notes scripts.

### DIFF
--- a/tools/build/github-release.sh
+++ b/tools/build/github-release.sh
@@ -2,13 +2,14 @@
 # Script to draft and edit Swift OPA GitHub releases. Assumes execution environment is Github Actions runner.
 
 set -x
+set -euo pipefail
 
 usage() {
     echo "github-release.sh  [--tag=<git tag>]"
     echo "    Default --tag is $TAG_NAME "
 }
 
-TAG_NAME=${TAG_NAME}
+TAG_NAME=${TAG_NAME:-}
 
 for i in "$@"; do
     case $i in
@@ -23,6 +24,12 @@ for i in "$@"; do
     esac
 done
 
+if [ -z "${TAG_NAME}" ]; then
+    echo "error: no tag provided (set TAG_NAME or pass --tag=<git tag>)" >&2
+    usage
+    exit 1
+fi
+
 # Gather the release notes from the CHANGELOG for the latest version
 RELEASE_NOTES="release-notes.md"
 
@@ -31,6 +38,13 @@ echo -e "${TAG_NAME}\n" > "${RELEASE_NOTES}"
 
 # Fill in the description
 ./tools/build/latest-release-notes.sh --output="${RELEASE_NOTES}"
+
+# Guard against publishing an empty release: the notes must contain more than
+# just the title line we seeded above.
+if [ "$(grep -vc -e '^[[:space:]]*$' -e "^${TAG_NAME}\$" "${RELEASE_NOTES}")" -eq 0 ]; then
+    echo "error: release notes for ${TAG_NAME} are empty (no CHANGELOG body extracted)" >&2
+    exit 1
+fi
 
 # Update or create a release on github
 if gh release view "${TAG_NAME}" --repo open-policy-agent/swift-opa > /dev/null; then

--- a/tools/build/latest-release-notes.sh
+++ b/tools/build/latest-release-notes.sh
@@ -2,8 +2,14 @@
 
 set -e
 
-PROJ_DIR=$(dirname "${BASH_SOURCE}")/..
+# This script lives in tools/build/, so the repo root is two levels up.
+PROJ_DIR=$(dirname "${BASH_SOURCE[0]}")/../..
 CHANGELOG="${PROJ_DIR}/CHANGELOG.md"
+
+if [ ! -f "${CHANGELOG}" ]; then
+    echo "error: CHANGELOG not found at ${CHANGELOG}" >&2
+    exit 1
+fi
 
 usage() {
     echo "latest-release-notes.sh --output=<path>"


### PR DESCRIPTION
### What code changed, and why?

The release note scripts have been failing to populate the Github Release draft with the CHANGELOG text for the last few releases, due to wrong path arguments in a few places. This was a side-effect of borrowing the scripts from other [open-policy-agent](https://github.com/open-policy-agent) projects that had different project structures.

The new scripts now include some guards to make it harder to accidentally point them at a non-existent file.

### How to test

For Github:
 - Merge PR. Observe if we get correct release notes in the draft next release.

For local testing:
 - Run from repo root: `./tools/build/latest-release-notes.sh --output="<example.md>"`, and check the results.

### Related Resources

