### PR TITLE
feat(builtins): urlquery encoding/decoding

### DIFF
--- a/Sources/Rego/Builtins/Encoding.swift
+++ b/Sources/Rego/Builtins/Encoding.swift
@@ -1,6 +1,11 @@
 import AST
 import Foundation
 
+/// Used by ``BuiltinFuncs/urlQueryEncodeObject(ctx:args:)`` for any
+/// non-conforming input shape.
+private let urlEncodeObjectErrMessage =
+    "operand 1 values must be string, array[string], or set[string]"
+
 extension BuiltinFuncs {
     // MARK: - base64.encode
     static func base64Encode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
@@ -256,6 +261,128 @@ extension BuiltinFuncs {
         // Returns the parsed RegoValue, or throws an error.
         return try JSONDecoder().decode(RegoValue.self, from: rawJSON.data(using: .utf8)!)
     }
+
+    // MARK: - urlquery.encode
+    /// URL-encodes a string. Mirrors Go's `net/url.QueryEscape`: spaces become
+    /// `+`; all bytes except `A-Z a-z 0-9 - _ . ~` become `%XX`.
+    public static func urlQueryEncode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        guard case .string(let s) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "x", got: args[0].typeName, want: "string")
+        }
+        return .string(queryEscape(s))
+    }
+
+    // MARK: - urlquery.decode
+    /// URL-decodes a string. Mirrors Go's `net/url.QueryUnescape`: `+` becomes
+    /// space, `%XX` becomes the byte, malformed `%` escapes throw.
+    public static func urlQueryDecode(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        guard case .string(let s) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "x", got: args[0].typeName, want: "string")
+        }
+        return .string(try queryUnescape(s))
+    }
+
+    // MARK: - urlquery.encode_object
+    /// Encodes an object as a URL query string. String values produce one
+    /// `k=v` pair; arrays/sets produce one pair per element. Object keys are
+    /// emitted in sorted order; arrays preserve element order; sets are sorted
+    /// for determinism.
+    public static func urlQueryEncodeObject(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        guard case .object(let obj) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "object", got: args[0].typeName, want: "object")
+        }
+
+        // Collect (key, value) pairs with string keys; sort by key for stable output.
+        var entries: [(String, AST.RegoValue)] = []
+        entries.reserveCapacity(obj.count)
+        for (key, val) in obj {
+            guard case .string(let k) = key else {
+                throw BuiltinError.evalError(msg: urlEncodeObjectErrMessage)
+            }
+            entries.append((k, val))
+        }
+        entries.sort { $0.0 < $1.0 }
+
+        var pairs: [String] = []
+        for (k, val) in entries {
+            let escapedKey = queryEscape(k)
+            switch val {
+            case .string(let s):
+                pairs.append("\(escapedKey)=\(queryEscape(s))")
+            case .array(let arr):
+                for elem in arr {
+                    guard case .string(let s) = elem else {
+                        throw BuiltinError.evalError(msg: urlEncodeObjectErrMessage)
+                    }
+                    pairs.append("\(escapedKey)=\(queryEscape(s))")
+                }
+            case .set(let set):
+                var members: [String] = []
+                members.reserveCapacity(set.count)
+                for elem in set {
+                    guard case .string(let s) = elem else {
+                        throw BuiltinError.evalError(msg: urlEncodeObjectErrMessage)
+                    }
+                    members.append(s)
+                }
+                members.sort()
+                for s in members {
+                    pairs.append("\(escapedKey)=\(queryEscape(s))")
+                }
+            default:
+                throw BuiltinError.evalError(msg: urlEncodeObjectErrMessage)
+            }
+        }
+
+        return .string(pairs.joined(separator: "&"))
+    }
+
+    // MARK: - urlquery.decode_object
+    /// Parses a URL query string into an object. Each key maps to an array of
+    /// values, since the same key may appear multiple times. Parameters with
+    /// no `=` decode to an empty-string value (e.g. `b` → `"b": [""]`).
+    public static func urlQueryDecodeObject(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard args.count == 1 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+        }
+        guard case .string(let s) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "x", got: args[0].typeName, want: "string")
+        }
+
+        guard !s.isEmpty else {
+            return .object([:])
+        }
+
+        var values: [String: [AST.RegoValue]] = [:]
+        // Match Go's `url.ParseQuery`: skip empty `&` pairs (so leading,
+        // trailing, and consecutive `&` are all dropped) and skip the lone
+        // `=` pair where both key and value are empty.
+        for pair in s.split(separator: "&", omittingEmptySubsequences: true) {
+            let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            let rawKey = String(parts[0])
+            let rawValue = parts.count > 1 ? String(parts[1]) : ""
+            if rawKey.isEmpty && rawValue.isEmpty { continue }
+            let key = try queryUnescape(rawKey)
+            let value = try queryUnescape(rawValue)
+            values[key, default: []].append(.string(value))
+        }
+
+        var result: [AST.RegoValue: AST.RegoValue] = [:]
+        result.reserveCapacity(values.count)
+        for (k, vs) in values {
+            result[.string(k)] = .array(vs)
+        }
+        return .object(result)
+    }
 }
 
 /// Helper extension to the Data to encode and decode hex strings
@@ -422,4 +549,81 @@ private func prettyPrintGolangStyle(json: String, indentWith: String, prefixWith
     }
 
     return String(decoding: out, as: UTF8.self)
+}
+
+// MARK: - URL query escape helpers
+
+/// Go `net/url.QueryEscape`: keep `A-Z a-z 0-9 - _ . ~` literal, encode space
+/// as `+`, percent-encode everything else as `%XX` (uppercase hex).
+private func queryEscape(_ s: String) -> String {
+    var out = [UInt8]()
+    out.reserveCapacity(s.utf8.count)
+    for byte in s.utf8 {
+        switch byte {
+        case 0x20:  // space
+            out.append(UInt8(ascii: "+"))
+        case 0x41...0x5A,  // A-Z
+            0x61...0x7A,  // a-z
+            0x30...0x39,  // 0-9
+            0x2D, 0x2E, 0x5F, 0x7E:  // - . _ ~
+            out.append(byte)
+        default:
+            out.append(UInt8(ascii: "%"))
+            out.append(hexNibble(byte >> 4))
+            out.append(hexNibble(byte & 0x0F))
+        }
+    }
+    return String(decoding: out, as: UTF8.self)
+}
+
+/// Go `net/url.QueryUnescape`: `+` → space, `%XX` → byte, malformed `%`
+/// throws `BuiltinError.evalError`. Error text matches Go's `url.EscapeError`
+/// format: `invalid URL escape "<bad>"`, where `<bad>` is the offending
+/// substring starting at `%` and capped at 3 bytes — same rule Go uses.
+private func queryUnescape(_ s: String) throws -> String {
+    let bytes = Array(s.utf8)
+    var out = [UInt8]()
+    out.reserveCapacity(bytes.count)
+    var i = 0
+    while i < bytes.count {
+        let b = bytes[i]
+        switch b {
+        case UInt8(ascii: "+"):
+            out.append(0x20)
+            i += 1
+        case UInt8(ascii: "%"):
+            guard i + 2 < bytes.count,
+                let h1 = hexValue(bytes[i + 1]),
+                let h2 = hexValue(bytes[i + 2])
+            else {
+                let end = Swift.min(i + 3, bytes.count)
+                let bad = String(decoding: bytes[i..<end], as: UTF8.self)
+                throw BuiltinError.evalError(msg: "invalid URL escape \"\(bad)\"")
+            }
+            out.append(UInt8((h1 << 4) | h2))
+            i += 3
+        default:
+            out.append(b)
+            i += 1
+        }
+    }
+    return String(decoding: out, as: UTF8.self)
+}
+
+/// Maps a 4-bit nibble (0-15) to its uppercase ASCII hex digit (`'0'`-`'9'`,
+/// `'A'`-`'F'`). Used by `queryEscape` to format `%XX` percent-escapes.
+private func hexNibble(_ n: UInt8) -> UInt8 {
+    return n < 10 ? n &+ UInt8(ascii: "0") : n &- 10 &+ UInt8(ascii: "A")
+}
+
+/// Inverse of `hexNibble` (case-insensitive). Returns the integer value of an
+/// ASCII hex digit, or `nil` if `b` is not a hex digit. Used by
+/// `queryUnescape` to parse `%XX` percent-escapes.
+private func hexValue(_ b: UInt8) -> Int? {
+    switch b {
+    case UInt8(ascii: "0")...UInt8(ascii: "9"): return Int(b) - Int(UInt8(ascii: "0"))
+    case UInt8(ascii: "A")...UInt8(ascii: "F"): return Int(b) - Int(UInt8(ascii: "A")) + 10
+    case UInt8(ascii: "a")...UInt8(ascii: "f"): return Int(b) - Int(UInt8(ascii: "a")) + 10
+    default: return nil
+    }
 }

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -187,6 +187,10 @@ public struct BuiltinRegistry: Sendable {
             "json.marshal": BuiltinFuncs.jsonMarshal,
             "json.marshal_with_options": BuiltinFuncs.jsonMarshalWithOptions,
             "json.unmarshal": BuiltinFuncs.jsonUnmarshal,
+            "urlquery.encode": BuiltinFuncs.urlQueryEncode,
+            "urlquery.decode": BuiltinFuncs.urlQueryDecode,
+            "urlquery.encode_object": BuiltinFuncs.urlQueryEncodeObject,
+            "urlquery.decode_object": BuiltinFuncs.urlQueryDecodeObject,
 
             // Numbers
             "numbers.range": BuiltinFuncs.numbersRange,

--- a/Tests/RegoTests/BuiltinTests/EncodingTests.swift
+++ b/Tests/RegoTests/BuiltinTests/EncodingTests.swift
@@ -376,6 +376,267 @@ extension BuiltinTests.EncodingTests {
         ),
     ]
 
+    // MARK: - urlquery.encode Tests
+    static let urlQueryEncodeTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "empty string",
+            name: "urlquery.encode",
+            args: [""],
+            expected: .success(.string(""))
+        ),
+        BuiltinTests.TestCase(
+            description: "compliance: a=b+1",
+            name: "urlquery.encode",
+            args: ["a=b+1"],
+            expected: .success(.string("a%3Db%2B1"))
+        ),
+        BuiltinTests.TestCase(
+            description: "space becomes plus",
+            name: "urlquery.encode",
+            args: ["hello world"],
+            expected: .success(.string("hello+world"))
+        ),
+        BuiltinTests.TestCase(
+            description: "unreserved characters pass through",
+            name: "urlquery.encode",
+            args: ["abcXYZ-._~"],
+            expected: .success(.string("abcXYZ-._~"))
+        ),
+        BuiltinTests.TestCase(
+            description: "unicode is utf-8 percent-encoded",
+            name: "urlquery.encode",
+            args: ["é"],
+            expected: .success(.string("%C3%A9"))
+        ),
+    ]
+
+    // MARK: - urlquery.decode Tests
+    static let urlQueryDecodeTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "empty string",
+            name: "urlquery.decode",
+            args: [""],
+            expected: .success(.string(""))
+        ),
+        BuiltinTests.TestCase(
+            description: "compliance: a%3Db%2B1",
+            name: "urlquery.decode",
+            args: ["a%3Db%2B1"],
+            expected: .success(.string("a=b+1"))
+        ),
+        BuiltinTests.TestCase(
+            description: "plus decodes to space",
+            name: "urlquery.decode",
+            args: ["hello+world"],
+            expected: .success(.string("hello world"))
+        ),
+        BuiltinTests.TestCase(
+            description: "lowercase hex accepted",
+            name: "urlquery.decode",
+            args: ["%c3%a9"],
+            expected: .success(.string("é"))
+        ),
+        BuiltinTests.TestCase(
+            description: "trailing %",
+            name: "urlquery.decode",
+            args: ["abc%"],
+            expected: .failure(BuiltinError.evalError(msg: "invalid URL escape \"%\""))
+        ),
+        BuiltinTests.TestCase(
+            description: "non-hex after %",
+            name: "urlquery.decode",
+            args: ["%ZZ"],
+            expected: .failure(BuiltinError.evalError(msg: "invalid URL escape \"%ZZ\""))
+        ),
+        BuiltinTests.TestCase(
+            description: "malformed escape mid-string clipped to 3 bytes",
+            name: "urlquery.decode",
+            args: ["abc%Zhello"],
+            expected: .failure(BuiltinError.evalError(msg: "invalid URL escape \"%Zh\""))
+        ),
+    ]
+
+    // MARK: - urlquery.encode_object Tests
+    static let urlQueryEncodeObjectTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "empty object",
+            name: "urlquery.encode_object",
+            args: [[:]],
+            expected: .success(.string(""))
+        ),
+        BuiltinTests.TestCase(
+            description: "compliance: strings sorted by key",
+            name: "urlquery.encode_object",
+            args: [["a": "b", "c": "d"]],
+            expected: .success(.string("a=b&c=d"))
+        ),
+        BuiltinTests.TestCase(
+            description: "keys emitted in sorted order regardless of literal order",
+            name: "urlquery.encode_object",
+            args: [["z": "1", "banana": "2", "apple": "3", "a": "4"]],
+            expected: .success(.string("a=4&apple=3&banana=2&z=1"))
+        ),
+        BuiltinTests.TestCase(
+            description: "value is escaped",
+            name: "urlquery.encode_object",
+            args: [["a": "c=b+1"]],
+            expected: .success(.string("a=c%3Db%2B1"))
+        ),
+        BuiltinTests.TestCase(
+            description: "array values produce repeated key",
+            name: "urlquery.encode_object",
+            args: [["a": ["b+1", "c+2"]]],
+            expected: .success(.string("a=b%2B1&a=c%2B2"))
+        ),
+        BuiltinTests.TestCase(
+            description: "set values produce repeated key (sorted)",
+            name: "urlquery.encode_object",
+            args: [["a": .set([.string("y"), .string("x")])]],
+            expected: .success(.string("a=x&a=y"))
+        ),
+        BuiltinTests.TestCase(
+            description: "mixed string and array values",
+            name: "urlquery.encode_object",
+            args: [["a": "1", "b": ["2", "3"]]],
+            expected: .success(.string("a=1&b=2&b=3"))
+        ),
+        BuiltinTests.TestCase(
+            description: "non-string value rejected",
+            name: "urlquery.encode_object",
+            args: [["a": 1]],
+            expected: .failure(
+                BuiltinError.evalError(
+                    msg: "operand 1 values must be string, array[string], or set[string]"))
+        ),
+        BuiltinTests.TestCase(
+            description: "non-string array element rejected",
+            name: "urlquery.encode_object",
+            args: [["a": [1, 2]]],
+            expected: .failure(
+                BuiltinError.evalError(
+                    msg: "operand 1 values must be string, array[string], or set[string]"))
+        ),
+        BuiltinTests.TestCase(
+            description: "non-string set element rejected",
+            name: "urlquery.encode_object",
+            args: [["a": .set([.number(1)])]],
+            expected: .failure(
+                BuiltinError.evalError(
+                    msg: "operand 1 values must be string, array[string], or set[string]"))
+        ),
+        BuiltinTests.TestCase(
+            description: "nested object value rejected",
+            name: "urlquery.encode_object",
+            args: [["a": ["nested": "value"]]],
+            expected: .failure(
+                BuiltinError.evalError(
+                    msg: "operand 1 values must be string, array[string], or set[string]"))
+        ),
+        BuiltinTests.TestCase(
+            description: "empty array value emits no pairs",
+            name: "urlquery.encode_object",
+            args: [["a": []]],
+            expected: .success(.string(""))
+        ),
+        BuiltinTests.TestCase(
+            description: "empty set value emits no pairs",
+            name: "urlquery.encode_object",
+            args: [["a": .set([])]],
+            expected: .success(.string(""))
+        ),
+    ]
+
+    // MARK: - urlquery.decode_object Tests
+    static let urlQueryDecodeObjectTests: [BuiltinTests.TestCase] = [
+        BuiltinTests.TestCase(
+            description: "empty string",
+            name: "urlquery.decode_object",
+            args: [""],
+            expected: .success(.object([:]))
+        ),
+        BuiltinTests.TestCase(
+            description: "compliance: multiple values per key",
+            name: "urlquery.decode_object",
+            args: ["a=value_a1&b=value_b&a=value_a2"],
+            expected: .success(["a": ["value_a1", "value_a2"], "b": ["value_b"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "compliance: param without =",
+            name: "urlquery.decode_object",
+            args: ["a=value_a1&b"],
+            expected: .success(["a": ["value_a1"], "b": [""]])
+        ),
+        BuiltinTests.TestCase(
+            description: "percent-decodes both keys and values",
+            name: "urlquery.decode_object",
+            args: ["a%20b=c%20d"],
+            expected: .success(["a b": ["c d"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "plus decodes to space",
+            name: "urlquery.decode_object",
+            args: ["a=hello+world"],
+            expected: .success(["a": ["hello world"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "malformed escape throws",
+            name: "urlquery.decode_object",
+            args: ["a=%ZZ"],
+            expected: .failure(BuiltinError.evalError(msg: "invalid URL escape \"%ZZ\""))
+        ),
+        // Empty-pair handling — match Go's `url.ParseQuery`, which silently
+        // skips empty `&` pairs (leading, trailing, consecutive) and the
+        // lone `=` pair where both sides are empty.
+        BuiltinTests.TestCase(
+            description: "leading separator",
+            name: "urlquery.decode_object",
+            args: ["&a=1"],
+            expected: .success(["a": ["1"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "trailing separator",
+            name: "urlquery.decode_object",
+            args: ["a=1&"],
+            expected: .success(["a": ["1"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "consecutive separators",
+            name: "urlquery.decode_object",
+            args: ["a=1&&b=2"],
+            expected: .success(["a": ["1"], "b": ["2"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "only separators",
+            name: "urlquery.decode_object",
+            args: ["&&"],
+            expected: .success(.object([:]))
+        ),
+        BuiltinTests.TestCase(
+            description: "lone equals is skipped",
+            name: "urlquery.decode_object",
+            args: ["="],
+            expected: .success(.object([:]))
+        ),
+        BuiltinTests.TestCase(
+            description: "empty key with non-empty value retained",
+            name: "urlquery.decode_object",
+            args: ["=value"],
+            expected: .success(["": ["value"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "escaped = in key is decoded after splitting",
+            name: "urlquery.decode_object",
+            args: ["a%3Db=value"],
+            expected: .success(["a=b": ["value"]])
+        ),
+        BuiltinTests.TestCase(
+            description: "literal = in value preserved (maxSplits 1)",
+            name: "urlquery.decode_object",
+            args: ["a=b=c"],
+            expected: .success(["a": ["b=c"]])
+        ),
+    ]
+
     static var allTests: [BuiltinTests.TestCase] {
         [
             BuiltinTests.generateFailureTests(
@@ -462,11 +723,60 @@ extension BuiltinTests.EncodingTests {
                 allowedArgTypes: ["string"],
                 generateNumberOfArgsTest: true),
             jsonUnmarshalTests,
+
+            BuiltinTests.generateFailureTests(
+                builtinName: "urlquery.encode", sampleArgs: [""],
+                argIndex: 0, argName: "x", allowedArgTypes: ["string"],
+                generateNumberOfArgsTest: true),
+            urlQueryEncodeTests,
+
+            BuiltinTests.generateFailureTests(
+                builtinName: "urlquery.decode", sampleArgs: [""],
+                argIndex: 0, argName: "x", allowedArgTypes: ["string"],
+                generateNumberOfArgsTest: true),
+            urlQueryDecodeTests,
+
+            BuiltinTests.generateFailureTests(
+                builtinName: "urlquery.encode_object", sampleArgs: [[:]],
+                argIndex: 0, argName: "object", allowedArgTypes: ["object"],
+                generateNumberOfArgsTest: true),
+            urlQueryEncodeObjectTests,
+
+            BuiltinTests.generateFailureTests(
+                builtinName: "urlquery.decode_object", sampleArgs: [""],
+                argIndex: 0, argName: "x", allowedArgTypes: ["string"],
+                generateNumberOfArgsTest: true),
+            urlQueryDecodeObjectTests,
         ].flatMap { $0 }
     }
 
     @Test(arguments: allTests)
     func testBuiltins(tc: BuiltinTests.TestCase) async throws {
         try await BuiltinTests.testBuiltin(tc: tc)
+    }
+
+    /// `decode(encode(s)) == s` for representative inputs covering reserved
+    /// chars, spaces, multi-byte UTF-8, and the full unreserved set.
+    @Test(
+        arguments: [
+            "",
+            "a=b+1",
+            "hello world",
+            "é",
+            "🚀 emoji",
+            "/?:#[]@!$&'()*+,;=",
+            "abcXYZ-._~",
+            "tab\tnewline\n",
+        ])
+    func testUrlQueryRoundTrip(input: String) async throws {
+        let registry = BuiltinRegistry.defaultRegistry
+        let ctx = BuiltinContext()
+        let encoded = try await registry.invoke(
+            withContext: ctx, name: "urlquery.encode",
+            args: [.string(input)], strict: true)
+        let decoded = try await registry.invoke(
+            withContext: ctx, name: "urlquery.decode",
+            args: [encoded], strict: true)
+        #expect(decoded == .string(input))
     }
 }

--- a/capabilities.json
+++ b/capabilities.json
@@ -2347,6 +2347,98 @@
           }
         ],
         "result" : {
+          "type" : "string"
+        },
+        "type" : "function"
+      },
+      "name" : "urlquery.decode"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
+          "dynamic" : {
+            "key" : {
+              "type" : "string"
+            },
+            "value" : {
+              "dynamic" : {
+                "type" : "string"
+              },
+              "type" : "array"
+            }
+          },
+          "type" : "object"
+        },
+        "type" : "function"
+      },
+      "name" : "urlquery.decode_object"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
+          "type" : "string"
+        },
+        "type" : "function"
+      },
+      "name" : "urlquery.encode"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "dynamic" : {
+              "key" : {
+                "type" : "string"
+              },
+              "value" : {
+                "of" : [
+                  {
+                    "type" : "string"
+                  },
+                  {
+                    "dynamic" : {
+                      "type" : "string"
+                    },
+                    "type" : "array"
+                  },
+                  {
+                    "of" : {
+                      "type" : "string"
+                    },
+                    "type" : "set"
+                  }
+                ],
+                "type" : "any"
+              }
+            },
+            "type" : "object"
+          }
+        ],
+        "result" : {
+          "type" : "string"
+        },
+        "type" : "function"
+      },
+      "name" : "urlquery.encode_object"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
           "dynamic" : {
             "key" : {
               "type" : "string"


### PR DESCRIPTION
### What code changed, and why?
Implemented 4 *new* `urlquery` builtins matching Go's net/url.QueryEscape/ QueryUnescape semantics. Malformed `%` escapes throw with Go's url.EscapeError text format.

`encode_object` enforces Go's contract — values must be `string`, `array[string]`, or `set[string]`. Keys emit sorted, arrays preserve order, sets are sorted for determinism.

`decode_object` skips empty `&` pairs and the lone `=` pair, matching `url.ParseQuery`. Each key maps to an array of values.

### Definition of done
New and existing unit tests pass, `urlbuiltins` compliance tests pass

### How to test
```
OPA_COMPLIANCE_TESTS=urlbuiltins make test-compliance
```
### Related Resources
Fixes: #173
