### PR TITLE
ci: Pin runner versions on older targets. Fix paths in `diff` PR check.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-15
             xcode: "16.2"
             swift: "6.0.3"
-          - os: macos-latest
+          - os: macos-15
             xcode: "16.4"
             swift: "6.1" # We can't go more modern than 6.1.0 for the 6.1 runner, due to Xcode version support.
           - os: macos-latest
@@ -101,11 +101,14 @@ jobs:
           ref: main
           path: main/swift-opa
           persist-credentials: false
+      # The reason we fetch the passed/failed filter scripts from the PR
+      # checkout folder, is so that we can change how those scripts work
+      # in a PR, and immediately see the results in this job step.
       - name: compliance tests (main)
         run: |
           (make test-compliance || true) > results
-          ../../../main/swift-opa/ComplianceSuite/tools/passed.sh < results > ../../../main-passed
-          ../../../main/swift-opa/ComplianceSuite/tools/failed.sh < results > ../../../main-failed
+          ../../../pr/swift-opa/ComplianceSuite/tools/passed.sh < results > ../../../main-passed
+          ../../../pr/swift-opa/ComplianceSuite/tools/failed.sh < results > ../../../main-failed
         working-directory: main/swift-opa/ComplianceSuite
       - name: compliance tests (pr)
         run: |


### PR DESCRIPTION
### What code changed, and why?

We've seen occasional mystery CI failures caused by the older versions of XCode disappearing. This is possibly due to the [`macos-latest` label migrating](https://github.com/actions/runner-images/issues/14167) to point to the [`macos-26` image](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md), instead of the earlier [`macos-15` image](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md).

This is a representative example for what the failures look like:
```
Run sudo xcode-select --switch "${DEVELOPER_DIR}/Contents/Developer"
xcode-select: error: invalid developer directory '/Applications/Xcode_16.4.app/Contents/Developer'
Error: Process completed with exit code 1.
```

This PR should eliminate those issues by explicitly pinning older Mac OS targets to the correct runner version.

Also included are some minor cleanups around the `diffs` job that was updated in #171.

### How to test

 - Watch CI over the next week or two, and see if we find any of the "Xcode version does not exist" path errors in CI. If so, then we have a different problem than expected.

### Related Resources

