### PR TITLE
ci: Add API breaking changes workflow.

### DIFF
--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -1,0 +1,30 @@
+name: API breaking changes
+
+on:
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-apibreakage
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: swift:latest # zizmor: ignore[unpinned-images]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark the workspace as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: API breaking changes
+        run: |
+          swift package diagnose-api-breaking-changes origin/${GITHUB_BASE_REF}


### PR DESCRIPTION
### What code changed, and why?

This commit adds a new workflow that runs a basic API breaking changes check as part of the standard PR checks.

The workflow is adapted nearly verbatim from [hummingbird-project/hummingbird](https://github.com/hummingbird-project/hummingbird/blob/main/.github/workflows/api-breakage.yml).

### How to test

### Related Resources

