### PR TITLE
chore: Upgrade swift-tools-version from 6.0 -> 6.1

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -15,8 +15,9 @@ permissions:
 
 jobs:
   ci:
-    name: Build Swift ${{ matrix.swift }}${{ matrix.xcode && format(', Xcode {0}', matrix.xcode) || '' }} (${{ matrix.os }})
+    name: Build Swift ${{ matrix.swift }}${{ matrix.xcode && format(', Xcode {0}', matrix.xcode) || '' }} (${{ matrix.container || matrix.os }})
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     permissions:
       contents: read
     strategy:
@@ -24,18 +25,23 @@ jobs:
       matrix:
         include:
           - os: macos-15
-            xcode: "16.2"
-            swift: "6.0.3"
-          - os: macos-15
             xcode: "16.4"
             swift: "6.1" # We can't go more modern than 6.1.0 for the 6.1 runner, due to Xcode version support.
-          - os: macos-latest
+          - os: macos-26
             xcode: "26.2"
             swift: "6.2.3"
+          - os: macos-26
+            xcode: "26.4"
+            swift: "6.3"
           - os: ubuntu-latest
-            swift: "6.0.3"
+            swift: "6.1"
+            container: "swift:6.1"
           - os: ubuntu-latest
             swift: "6.2"
+            container: "swift:6.2"
+          - os: ubuntu-latest
+            swift: "6.3"
+            container: "swift:6.3"
     env:
       XCODE_VERSION: ${{ matrix.xcode }}
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
@@ -46,10 +52,6 @@ jobs:
         run: |
           sudo xcode-select --switch "${DEVELOPER_DIR}/Contents/Developer"
           xcodebuild -version
-      - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a #v2.4.0
-        if: runner.os == 'Linux'
-        with:
-          swift-version: ${{ matrix.swift }}
       - name: Show Swift version
         run: swift --version
       - name: Fail if Swift version does not match expected version (${{ matrix.swift }})
@@ -66,9 +68,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Install jemalloc
+      - name: Install jemalloc (macOS)
         if: runner.os == 'macOS'
         run: brew install jemalloc
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          apt-get update
+          apt-get install -y libjemalloc-dev make
       - name: Lint
         run: make lint
       - name: Test

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import PackageDescription
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Swift Tools Version updated to 6.1
+
+We have recently updated the [minimum Swift toolchain version](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/settingswifttoolsversion/) required to build Swift OPA from 6.0 to 6.1.
+
+This change gives the project access to [package traits](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/packagetraits/), which will allow us to separate out optional dependencies better.
+
 ## 0.0.8
 
 This release is a test for some recent release engineering changes.

--- a/ComplianceSuite/Package.swift
+++ b/ComplianceSuite/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ We recommend sticking to the supported RE2 regex syntax, in order to avoid futur
 
 </details>
 
+## Version Support
+
+We aim to support "latest Swift major version - 2" releases back. As an example, for Swift 6.4, that implies supporting Swift 6.3, and 6.2 as well.
+
 ## Community Support
 
 Feel free to open and issue if you encounter any problems using swift-opa, or have ideas on how to make it even better.

--- a/tools/SyncGen/Package.swift
+++ b/tools/SyncGen/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
### What code changed, and why?

This PR upgrades our [`swift-tools-version`](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/settingswifttoolsversion/) settings to indicate Swift 6.1 is the minimum supported toolchain version for building the project. 

This change gives the project access to [package traits](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/packagetraits/), which will allow us to separate out optional dependencies better.

Also included is a README update, spelling out our "latest - 2" major Swift version support policy going forward.

### How to test

 - ~~Our 6.0.3 builds should fail. I'll remove them after making sure they explode as-intended.~~
 - If our CI builds properly across 6.1 - 6.3 targets on both Linux and MacOS build targets, we should be good.

### Related Resources

