### PR TITLE
chore: Bump minimum OS versions, macOS v13 -> v15 and iOS v16 -> v18

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "swift-opa-benchmarks",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v15)
     ],
     dependencies: [
         .package(name: "swift-opa", path: ".."),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Swift Tools Version updated to 6.1
 
-We have recently updated the [minimum Swift toolchain version](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/settingswifttoolsversion/) required to build Swift OPA from 6.0 to 6.1.
+We have updated the [minimum Swift toolchain version](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/settingswifttoolsversion/) required to build Swift OPA from 6.0 to 6.1.
 
 This change gives the project access to [package traits](https://docs.swift.org/swiftpm/documentation/packagemanagerdocs/packagetraits/), which will allow us to separate out optional dependencies better.
+
+### Minimum platform OS versions updated for macOS and iOS
+
+We have updated the minimum platform OS versions required to build Swift OPA from `.macOS(.v13)` -> `.macOS(.v15)` and `.iOS(.v16)` -> `.iOS(.v18)`.
+
+Bumping the OS versions allows us to use [`Mutex<T>`](https://developer.apple.com/documentation/synchronization/mutex) and other newer Swift APIs.
 
 ## 0.0.8
 

--- a/ComplianceSuite/Package.swift
+++ b/ComplianceSuite/Package.swift
@@ -10,7 +10,7 @@ let swiftOpaDependencyPath = ProcessInfo.processInfo.environment["SWIFT_OPA_DEPE
 let package = Package(
     name: "RegoCompliance",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ import class Foundation.ProcessInfo
 let package = Package(
     name: "swift-opa",
     platforms: [
-        .macOS(.v13),
-        .iOS(.v16),
+        .macOS(.v15),
+        .iOS(.v18),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ We recommend sticking to the supported RE2 regex syntax, in order to avoid futur
 
 We aim to support "latest Swift major version - 2" releases back. As an example, for Swift 6.4, that implies supporting Swift 6.3, and 6.2 as well.
 
+For `.macOS` and `.iOS` platform versions, we aim to support the platform versions associated with the current and previous major macOS releases. For example, if the current macOS release is macOS 26 "Tahoe", then the previous major release was macOS 15 "Sequoia", and we would support the `.macOS(.v15)` target, as well as the iOS version that released at the same time, `.iOS(.v18)`.
+
 ## Community Support
 
 Feel free to open and issue if you encounter any problems using swift-opa, or have ideas on how to make it even better.

--- a/tools/SyncGen/Package.swift
+++ b/tools/SyncGen/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "SyncGen",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v15)],
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0")
     ],


### PR DESCRIPTION
### What code changed, and why?

This PR upgrades our minimum supported OS versions from `.macOS(.v13)` -> `.macOS(.v15)` and `.iOS(.v16)` -> `.iOS(.v18)`

Bumping the OS versions gets us access to [`Mutex<T>`](https://developer.apple.com/documentation/synchronization/mutex) and other newer Swift APIs, among other things.

The PR also adds a note about our OS version support policy to the README.

### How to test

 - Do our CI targets all still build? 😅 

### Related Resources

