### PR TITLE
feat(builtins): implement object.filter, remove, subset

### DIFF
--- a/Sources/Rego/Builtins/Objects.swift
+++ b/Sources/Rego/Builtins/Objects.swift
@@ -131,4 +131,202 @@ extension BuiltinFuncs {
 
         return .object(result)
     }
+
+    // filter returns a new object with only the keys of the input object that are
+    // present in the keys argument. keys may be an array, set, or object.
+    // args
+    // object (object[any: any]) - object to filter keys
+    // keys (any<array[any], object[any: any], set[any]>) - keys to keep in object
+    // returns: filtered (any) - remaining data from object with only keys specified in keys
+    static func objectFilter(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard args.count == 2 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
+        }
+
+        guard case .object(let object) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "object", got: args[0].typeName, want: "object")
+        }
+
+        let keys = try keysArgumentAsSet(args[1], arg: "keys")
+
+        // Result holds at most one entry per key that also exists in
+        // the object.
+        var result: [AST.RegoValue: AST.RegoValue] = [:]
+        result.reserveCapacity(Swift.min(keys.count, object.count))
+        for key in keys {
+            if let value = object[key] {
+                result[key] = value
+            }
+        }
+
+        return .object(result)
+    }
+
+    // remove returns a new object with the specified keys removed from the input object.
+    // keys may be an array, set, or object.
+    // args
+    // object (object[any: any]) - object to remove keys from
+    // keys (any<array[any], object[any: any], set[any]>) - keys to remove from object
+    // returns: output (any) - result of removing the specified keys from object
+    static func objectRemove(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard args.count == 2 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
+        }
+
+        guard case .object(let object) = args[0] else {
+            throw BuiltinError.argumentTypeMismatch(arg: "object", got: args[0].typeName, want: "object")
+        }
+
+        let keysToRemove = try keysArgumentAsSet(args[1], arg: "keys")
+
+        guard !keysToRemove.isEmpty else {
+            return .object(object)
+        }
+
+        var result: [AST.RegoValue: AST.RegoValue] = [:]
+        result.reserveCapacity(Swift.max(0, object.count - keysToRemove.count))
+        for (key, value) in object where !keysToRemove.contains(key) {
+            result[key] = value
+        }
+
+        return .object(result)
+    }
+
+    // subset determines if the sub value is a subset of the super value.
+    // args
+    // super (any<object[any: any], set[any], array[any]>) - object, set, or array to check against
+    // sub (any<object[any: any], set[any], array[any]>) - object, set, or array to check
+    // returns: result (boolean) - true if sub is a subset of super
+    static func objectSubset(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+        guard args.count == 2 else {
+            throw BuiltinError.argumentCountMismatch(got: args.count, want: 2)
+        }
+
+        return .boolean(try isSubset(super: args[0], sub: args[1]))
+    }
+
+    // MARK: - Private helpers
+
+    // isArrayASubsetOfAnotherArray returns true when sub appears as a contiguous, in-order
+    // subsequence of super.
+    private static func isArrayASubsetOfAnotherArray(super superArr: [AST.RegoValue], sub subArr: [AST.RegoValue])
+        -> Bool
+    {
+        guard let first = subArr.first else {
+            return true
+        }
+        guard superArr.count >= subArr.count else {
+            return false
+        }
+
+        // We use a filtered for loop to skip starting indices that don't
+        // match the start of the sub-array's sequence.
+        for start in 0...(superArr.count - subArr.count) where superArr[start] == first {
+            // Match the rest of the sequence normally.
+            var matched = true
+            for offset in 1..<subArr.count where superArr[start + offset] != subArr[offset] {
+                matched = false
+                break
+            }
+            if matched {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // isObjectASubsetOfAnotherObject returns true when every key in sub is present in
+    // super and the corresponding values are subsets. Nested objects, sets, and arrays
+    // are checked recursively; all other values must be equal.
+    private static func isObjectASubsetOfAnotherObject(
+        super superObj: [AST.RegoValue: AST.RegoValue], sub subObj: [AST.RegoValue: AST.RegoValue]
+    ) -> Bool {
+        for (key, subChild) in subObj {
+            guard let superChild = superObj[key] else {
+                return false
+            }
+            if subChild == superChild {
+                continue
+            }
+            switch (superChild, subChild) {
+            case (.object(let superChildObj), .object(let subChildObj)):
+                if !isObjectASubsetOfAnotherObject(super: superChildObj, sub: subChildObj) {
+                    return false
+                }
+            case (.set(let superChildSet), .set(let subChildSet)):
+                if !subChildSet.isSubset(of: superChildSet) {
+                    return false
+                }
+            case (.array(let superChildArr), .array(let subChildArr)):
+                if !isArrayASubsetOfAnotherArray(super: superChildArr, sub: subChildArr) {
+                    return false
+                }
+            default:
+                return false
+            }
+        }
+
+        return true
+    }
+
+    // isSetASubsetOfArray returns true when every member of subset appears somewhere in the
+    // super array, without regard to ordering.
+    private static func isSetASubsetOfArray(super superArr: [AST.RegoValue], sub subSet: Set<AST.RegoValue>) -> Bool {
+        // Mirrors OPA's arraySetSubset implementation.
+        var unmatched = subSet.count
+        for element in superArr {
+            if subSet.contains(element) {
+                unmatched -= 1
+            }
+            if unmatched == 0 {
+                return true
+            }
+        }
+        return false
+    }
+
+    // isSubset implements the subset relation across the supported type combinations.
+    // Both operands must be the same type (both objects, both sets, or both arrays),
+    // with the single exception that a set may be checked against an array, in which
+    // case the set members must appear somewhere in the array.
+    private static func isSubset(super superValue: AST.RegoValue, sub subValue: AST.RegoValue) throws -> Bool {
+        switch (superValue, subValue) {
+        case (.object(let superObj), .object(let subObj)):
+            return isObjectASubsetOfAnotherObject(super: superObj, sub: subObj)
+        case (.set(let superSet), .set(let subSet)):
+            return subSet.isSubset(of: superSet)
+        case (.array(let superArr), .array(let subArr)):
+            return isArrayASubsetOfAnotherArray(super: superArr, sub: subArr)
+        case (.array(let superArr), .set(let subSet)):
+            return isSetASubsetOfArray(super: superArr, sub: subSet)
+        default:
+            throw BuiltinError.evalError(
+                msg: "both arguments object.subset must be of the same type or array and set")
+        }
+    }
+
+    // keysArgumentAsSet interprets the second ("keys") argument of object.filter and
+    // object.remove as the set of keys it references.
+    //
+    // Both filter and remove builtins accept the argument as one of three interchangeable
+    // forms - an array (its elements are the keys), a set (its members are the keys), or
+    // an object (its own keys are the keys). Regardless of the form, filter and remove only
+    // need to test membership ("is this object key named?"). Normalizing all three
+    // forms into a single Set lets both builtins share identical lookup logic instead
+    // of each repeating the same type switch, and gives one place to raise the type error
+    // for an unsupported shape. This mirrors upstream OPA's getObjectKeysParam helper.
+    private static func keysArgumentAsSet(_ value: AST.RegoValue, arg: String) throws -> Set<AST.RegoValue> {
+        switch value {
+        case .array(let arr):
+            return Set(arr)
+        case .set(let set):
+            return set
+        case .object(let obj):
+            return Set(obj.keys)
+        default:
+            throw BuiltinError.argumentTypeMismatch(
+                arg: arg, got: value.typeName, want: "any<array[any], object[any: any], set[any]>")
+        }
+    }
 }

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -197,8 +197,11 @@ public struct BuiltinRegistry: Sendable {
             "numbers.range_step": BuiltinFuncs.numbersRangeStep,
 
             // Objects
+            "object.filter": BuiltinFuncs.objectFilter,
             "object.get": BuiltinFuncs.objectGet,
             "object.keys": BuiltinFuncs.objectKeys,
+            "object.remove": BuiltinFuncs.objectRemove,
+            "object.subset": BuiltinFuncs.objectSubset,
             "object.union": BuiltinFuncs.objectUnion,
             "object.union_n": BuiltinFuncs.objectUnionN,
 

--- a/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
+++ b/Tests/RegoTests/BuiltinTests/ObjectsTests.swift
@@ -588,12 +588,397 @@ extension BuiltinTests.ObjectTests {
         ),
     ]
 
+    static let objectFilterKeysWant = "any<array[any], object[any: any], set[any]>"
+
+    static let objectFilterTests: [BuiltinTests.TestCase] =
+        [
+            BuiltinTests.TestCase(
+                description: "filter with set of keys",
+                name: "object.filter",
+                args: [
+                    ["a": 1, "b": 2, "c": 3],
+                    .set(["a", "c"]),
+                ],
+                expected: .success(.object(["a": 1, "c": 3]))
+            ),
+            BuiltinTests.TestCase(
+                description: "filter with array of keys",
+                name: "object.filter",
+                args: [
+                    ["a": 1, "b": 2],
+                    .array(["b"]),
+                ],
+                expected: .success(.object(["b": 2]))
+            ),
+            BuiltinTests.TestCase(
+                description: "filter with object keys (values ignored)",
+                name: "object.filter",
+                args: [
+                    ["a": 1, "b": 2],
+                    ["a": "ignored"],
+                ],
+                expected: .success(.object(["a": 1]))
+            ),
+            BuiltinTests.TestCase(
+                description: "key requested but not present is skipped",
+                name: "object.filter",
+                args: [
+                    ["a": 1],
+                    .set(["a", "zz"]),
+                ],
+                expected: .success(.object(["a": 1]))
+            ),
+            BuiltinTests.TestCase(
+                description: "empty keys yields empty object",
+                name: "object.filter",
+                args: [
+                    ["a": 1, "b": 2],
+                    .set([]),
+                ],
+                expected: .success(.object([:]))
+            ),
+            BuiltinTests.TestCase(
+                description: "empty object yields empty object",
+                name: "object.filter",
+                args: [
+                    [:],
+                    .set(["a"]),
+                ],
+                expected: .success(.object([:]))
+            ),
+            BuiltinTests.TestCase(
+                description: "nested values preserved",
+                name: "object.filter",
+                args: [
+                    ["a": ["x": 1], "b": 2],
+                    .set(["a"]),
+                ],
+                expected: .success(.object(["a": ["x": 1]]))
+            ),
+            BuiltinTests.TestCase(
+                description: "non string keys",
+                name: "object.filter",
+                args: [
+                    .object([.array([7]): 2, "a": 1]),
+                    .set([.array([7])]),
+                ],
+                expected: .success(.object([.array([7]): 2]))
+            ),
+        ]
+        + BuiltinTests.generateFailureTests(
+            builtinName: "object.filter",
+            sampleArgs: [["a": 1], .set(["a"])],
+            argIndex: 0,
+            argName: "object",
+            allowedArgTypes: ["object"],
+            generateNumberOfArgsTest: true
+        )
+        + BuiltinTests.generateFailureTests(
+            builtinName: "object.filter",
+            sampleArgs: [["a": 1], .set(["a"])],
+            argIndex: 1,
+            argName: "keys",
+            allowedArgTypes: ["array", "object", "set"],
+            wantArgs: objectFilterKeysWant
+        )
+
+    static let objectRemoveTests: [BuiltinTests.TestCase] =
+        [
+            BuiltinTests.TestCase(
+                description: "remove with set of keys",
+                name: "object.remove",
+                args: [
+                    ["a": 1, "b": 2, "c": 3],
+                    .set(["b"]),
+                ],
+                expected: .success(.object(["a": 1, "c": 3]))
+            ),
+            BuiltinTests.TestCase(
+                description: "remove with array of keys",
+                name: "object.remove",
+                args: [
+                    ["a": 1, "b": 2],
+                    .array(["a"]),
+                ],
+                expected: .success(.object(["b": 2]))
+            ),
+            BuiltinTests.TestCase(
+                description: "remove with object keys (values ignored)",
+                name: "object.remove",
+                args: [
+                    ["a": 1, "b": 2],
+                    ["a": "ignored"],
+                ],
+                expected: .success(.object(["b": 2]))
+            ),
+            BuiltinTests.TestCase(
+                description: "removing a key that doesn't exist is a no-op",
+                name: "object.remove",
+                args: [
+                    ["a": 1],
+                    .set(["zz"]),
+                ],
+                expected: .success(.object(["a": 1]))
+            ),
+            BuiltinTests.TestCase(
+                description: "remove all keys yields empty object",
+                name: "object.remove",
+                args: [
+                    ["a": 1, "b": 2],
+                    .set(["a", "b"]),
+                ],
+                expected: .success(.object([:]))
+            ),
+            BuiltinTests.TestCase(
+                description: "empty keys leaves object unchanged",
+                name: "object.remove",
+                args: [
+                    ["a": 1],
+                    .set([]),
+                ],
+                expected: .success(.object(["a": 1]))
+            ),
+            BuiltinTests.TestCase(
+                description: "empty object yields empty object",
+                name: "object.remove",
+                args: [
+                    [:],
+                    .set(["a"]),
+                ],
+                expected: .success(.object([:]))
+            ),
+            BuiltinTests.TestCase(
+                description: "non string keys",
+                name: "object.remove",
+                args: [
+                    .object([.array([7]): 2, "a": 1]),
+                    .set([.array([7])]),
+                ],
+                expected: .success(.object(["a": 1]))
+            ),
+        ]
+        + BuiltinTests.generateFailureTests(
+            builtinName: "object.remove",
+            sampleArgs: [["a": 1], .set(["a"])],
+            argIndex: 0,
+            argName: "object",
+            allowedArgTypes: ["object"],
+            generateNumberOfArgsTest: true
+        )
+        + BuiltinTests.generateFailureTests(
+            builtinName: "object.remove",
+            sampleArgs: [["a": 1], .set(["a"])],
+            argIndex: 1,
+            argName: "keys",
+            allowedArgTypes: ["array", "object", "set"],
+            wantArgs: objectFilterKeysWant
+        )
+
+    static let objectSubsetTypeError = BuiltinError.evalError(
+        msg: "both arguments object.subset must be of the same type or array and set")
+
+    static let objectSubsetTests: [BuiltinTests.TestCase] =
+        [
+            // object / object
+            BuiltinTests.TestCase(
+                description: "object: simple subset",
+                name: "object.subset",
+                args: [["a": 1, "b": 2], ["a": 1]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: equal objects",
+                name: "object.subset",
+                args: [["a": 1], ["a": 1]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: missing key",
+                name: "object.subset",
+                args: [["a": 1], ["b": 1]],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: value mismatch",
+                name: "object.subset",
+                args: [["a": 1], ["a": 2]],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: nested object subset recurses (true)",
+                name: "object.subset",
+                args: [["a": ["b": 1, "c": 2]], ["a": ["b": 1]]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: nested object subset recurses (false)",
+                name: "object.subset",
+                args: [["a": ["b": 1]], ["a": ["b": 1, "c": 2]]],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: nested set subset recurses (true)",
+                name: "object.subset",
+                args: [["a": .set([1, 2, 3])], ["a": .set([1, 2])]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: nested set subset recurses (false)",
+                name: "object.subset",
+                args: [["a": .set([1])], ["a": .set([1, 2])]],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: nested array subset recurses (true)",
+                name: "object.subset",
+                args: [["a": [1, 2, 3, 4]], ["a": [2, 3]]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: nested array subset recurses (false, not contiguous)",
+                name: "object.subset",
+                args: [["a": [1, 2, 3]], ["a": [1, 3]]],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "object: nested value type mismatch",
+                name: "object.subset",
+                args: [["a": 1], ["a": .set([1])]],
+                expected: .success(.boolean(false))
+            ),
+            // set / set
+            BuiltinTests.TestCase(
+                description: "set: subset",
+                name: "object.subset",
+                args: [.set([1, 2, 3]), .set([1, 2])],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "set: not a subset",
+                name: "object.subset",
+                args: [.set([1, 2]), .set([1, 3])],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "set: empty sub is a subset",
+                name: "object.subset",
+                args: [.set([1]), .set([])],
+                expected: .success(.boolean(true))
+            ),
+            // array / array
+            BuiltinTests.TestCase(
+                description: "array: contiguous subslice",
+                name: "object.subset",
+                args: [[1, 2, 3, 4], [2, 3]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "array: non-contiguous is not a subset",
+                name: "object.subset",
+                args: [[1, 2, 3, 4], [1, 3]],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "array: equal arrays",
+                name: "object.subset",
+                args: [[1, 2, 3], [1, 2, 3]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "array: subslice at start",
+                name: "object.subset",
+                args: [[1, 2, 3], [1, 2]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "array: subslice at end",
+                name: "object.subset",
+                args: [[1, 2, 3], [2, 3]],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "array: empty sub is a subset",
+                name: "object.subset",
+                args: [[1, 2], .array([])],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "array: sub bigger than super",
+                name: "object.subset",
+                args: [[1], [1, 2]],
+                expected: .success(.boolean(false))
+            ),
+            // array (super) / set (sub) - the one supported mixed case
+            BuiltinTests.TestCase(
+                description: "array super, set sub: all members present (order irrelevant)",
+                name: "object.subset",
+                args: [[1, 2, 3], .set([3, 1])],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "array super, set sub: member missing",
+                name: "object.subset",
+                args: [[1, 2, 3], .set([4])],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "array super, set sub: empty set",
+                name: "object.subset",
+                args: [[1, 2], .set([])],
+                expected: .success(.boolean(true))
+            ),
+            // type mismatches - error
+            BuiltinTests.TestCase(
+                description: "object super, set sub is unsupported",
+                name: "object.subset",
+                args: [["a": 1], .set(["a"])],
+                expected: .failure(objectSubsetTypeError)
+            ),
+            BuiltinTests.TestCase(
+                description: "object super, array sub is unsupported",
+                name: "object.subset",
+                args: [["a": 1], .array(["a"])],
+                expected: .failure(objectSubsetTypeError)
+            ),
+            BuiltinTests.TestCase(
+                description: "set super, object sub is unsupported",
+                name: "object.subset",
+                args: [.set([1]), ["a": 1]],
+                expected: .failure(objectSubsetTypeError)
+            ),
+            BuiltinTests.TestCase(
+                description: "set super, array sub is unsupported",
+                name: "object.subset",
+                args: [.set([1]), [1]],
+                expected: .failure(objectSubsetTypeError)
+            ),
+            BuiltinTests.TestCase(
+                description: "array super, object sub is unsupported",
+                name: "object.subset",
+                args: [[1], ["a": 1]],
+                expected: .failure(objectSubsetTypeError)
+            ),
+            BuiltinTests.TestCase(
+                description: "scalar arguments are unsupported",
+                name: "object.subset",
+                args: [.number(1), .number(1)],
+                expected: .failure(objectSubsetTypeError)
+            ),
+        ]
+        + BuiltinTests.generateNumberOfArgumentsFailureTests(
+            builtinName: "object.subset",
+            sampleArgs: [["a": 1], ["a": 1]]
+        )
+
     static var allTests: [BuiltinTests.TestCase] {
         [
             objectGetTests,
             objectKeysTests,
             objectUnionTests,
             objectUnionNTests,
+            objectFilterTests,
+            objectRemoveTests,
+            objectSubsetTests,
         ].flatMap { $0 }
     }
 

--- a/capabilities.json
+++ b/capabilities.json
@@ -1227,6 +1227,56 @@
             "type" : "object"
           },
           {
+            "of" : [
+              {
+                "dynamic" : {
+                  "type" : "any"
+                },
+                "type" : "array"
+              },
+              {
+                "dynamic" : {
+                  "key" : {
+                    "type" : "any"
+                  },
+                  "value" : {
+                    "type" : "any"
+                  }
+                },
+                "type" : "object"
+              },
+              {
+                "of" : {
+                  "type" : "any"
+                },
+                "type" : "set"
+              }
+            ],
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "type" : "any"
+        },
+        "type" : "function"
+      },
+      "name" : "object.filter"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "dynamic" : {
+              "key" : {
+                "type" : "any"
+              },
+              "value" : {
+                "type" : "any"
+              }
+            },
+            "type" : "object"
+          },
+          {
             "type" : "any"
           },
           {
@@ -1264,6 +1314,123 @@
         "type" : "function"
       },
       "name" : "object.keys"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "dynamic" : {
+              "key" : {
+                "type" : "any"
+              },
+              "value" : {
+                "type" : "any"
+              }
+            },
+            "type" : "object"
+          },
+          {
+            "of" : [
+              {
+                "dynamic" : {
+                  "type" : "any"
+                },
+                "type" : "array"
+              },
+              {
+                "dynamic" : {
+                  "key" : {
+                    "type" : "any"
+                  },
+                  "value" : {
+                    "type" : "any"
+                  }
+                },
+                "type" : "object"
+              },
+              {
+                "of" : {
+                  "type" : "any"
+                },
+                "type" : "set"
+              }
+            ],
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "type" : "any"
+        },
+        "type" : "function"
+      },
+      "name" : "object.remove"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "of" : [
+              {
+                "dynamic" : {
+                  "type" : "any"
+                },
+                "type" : "array"
+              },
+              {
+                "dynamic" : {
+                  "key" : {
+                    "type" : "any"
+                  },
+                  "value" : {
+                    "type" : "any"
+                  }
+                },
+                "type" : "object"
+              },
+              {
+                "of" : {
+                  "type" : "any"
+                },
+                "type" : "set"
+              }
+            ],
+            "type" : "any"
+          },
+          {
+            "of" : [
+              {
+                "dynamic" : {
+                  "type" : "any"
+                },
+                "type" : "array"
+              },
+              {
+                "dynamic" : {
+                  "key" : {
+                    "type" : "any"
+                  },
+                  "value" : {
+                    "type" : "any"
+                  }
+                },
+                "type" : "object"
+              },
+              {
+                "of" : {
+                  "type" : "any"
+                },
+                "type" : "set"
+              }
+            ],
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "type" : "any"
+        },
+        "type" : "function"
+      },
+      "name" : "object.subset"
     },
     {
       "decl" : {


### PR DESCRIPTION
### What code changed, and why?
Add the remaining `object.*` builtins, matching OPA Go semantics.

`filter`/`remove` accept the keys argument as an array, set, or object (including non-string keys), normalized into a single key set shared by both. object.subset acts on the operand type pair: object/object, set/set, array/array, and the array/set-as-subset case only. Other combinations (e.g. object/set) cause evaluation errors. Subsets are checked recursively for nested objects/sets/arrays, and arrays match as contiguous, in-order slices, not arbitrary subsequences.

### Definition of done
All remaining `object|subset` compliance tests pass.

### How to test
`make fmt lint test`
`OPA_COMPLIANCE_TESTS=".*(object|subset).*" make test-compliance`

### Related Resources
Fixes #186
