### PR TITLE
perf: avoid NSString bridge in queryToEntryPoint

### DIFF
--- a/Sources/Rego/IREvaluator.swift
+++ b/Sources/Rego/IREvaluator.swift
@@ -215,5 +215,7 @@ func queryToEntryPoint(_ query: String) throws -> String {
         // done!
         return query
     }
-    return query.dropFirst(prefix.count + 1).replacingOccurrences(of: ".", with: "/")
+    // Hot path: called once per evaluate(). Avoid Foundation's
+    // replacingOccurrences(of:with:), which bridges to NSString on Linux.
+    return String(query.dropFirst(prefix.count + 1).map { $0 == "." ? "/" : $0 })
 }


### PR DESCRIPTION
## What

`queryToEntryPoint()` runs once per `evaluate()` (the per-query hot path). It turns a query like `data.foo.bar` into the entrypoint path `foo/bar` via `String.replacingOccurrences(of: ".", with: "/")`.

On **Linux**, `replacingOccurrences(of:with:)` bridges to Foundation `NSString` — each call allocates an `NSMutableString` and runs `CFStringCreateArrayWithFindResults` + `CFStringFindWithOptionsAndLocale` + a mutable copy, just to swap one character. This replaces it with a pure-Swift scalar swap (`.` → `/`), which is semantically identical and allocation-light.

```diff
-    return query.dropFirst(prefix.count + 1).replacingOccurrences(of: ".", with: "/")
+    // Hot path: called once per evaluate(). Avoid Foundation's
+    // replacingOccurrences(of:with:), which bridges to NSString on Linux.
+    return String(query.dropFirst(prefix.count + 1).map { $0 == "." ? "/" : $0 })
```

## Benchmarks

`cd Benchmarks && swift package benchmark` with `baseline compare` (Linux/aarch64, Swift 6.3.1, `BENCHMARK_MAX_DURATION_SECONDS=3`, `BENCHMARK_WARMUP_ITERATIONS=100`). A **deterministic −12 malloc / −6 object-alloc drop per `evaluate()`**, identical across every percentile (the vanishing NSString-bridge allocations):

| Benchmark | Malloc (total) | Object allocs | Wall clock (p50) |
|---|---|---|---|
| Simple Policy Evaluation | **−24%** | **−29%** | ~−16% |
| Simple Policy Evaluation (async / sync) | ~−20% | −29% | ~−19% |
| Array Iteration / Build Literal / Dynamic Call | −6…−20% | −5…−29% | −7…−17% |

Wall-clock improves too but is noisier run-to-run; the allocation deltas are deterministic.

## Correctness

Semantically identical (single-character `.`→`/` swap). Full suite green: **306 tests / 57 suites pass**.
