### PR TITLE
builtins: Add yaml.* builtins + new YAML trait.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### `yaml.is_valid`, `yaml.marshal`, `yaml.unmarshal` builtins
+
+Swift OPA now supports the `yaml.*` builtins:
+
+- [`yaml.is_valid`](https://www.openpolicyagent.org/docs/policy-reference/builtins/yaml#builtin-yaml-yamlis_valid)
+- [`yaml.marshal`](https://www.openpolicyagent.org/docs/policy-reference/builtins/yaml#builtin-yaml-yamlmarshal)
+- [`yaml.unmarshal`](https://www.openpolicyagent.org/docs/policy-reference/builtins/yaml#builtin-yaml-yamlunmarshal)
+
+These are backed by [Yams](https://github.com/jpsim/Yams), which is gated behind a new,
+default-enabled `YAML` package trait. Library-only consumers can disable the trait to
+drop the Yams dependency from their build. When disabled, the `yaml.*` builtins are not
+registered.
+
 ## 0.0.9
 
 This release includes small performance improvements, new `object.*` builtins, and upgrades our minimum Swift toolchain and OS versions.

--- a/Package.swift
+++ b/Package.swift
@@ -22,16 +22,21 @@ let package = Package(
         ),
     ],
     traits: [
-        // Enabled by default. Library-only consumers can opt out to drop the CLI and its
-        // dependencies from resolution.
-        .default(enabledTraits: ["CLI"]),
+        // Enabled by default. Library-only consumers can opt out to drop optional
+        // features and dependencies from the build.
+        .default(enabledTraits: ["CLI", "YAML"]),
         Trait(
             name: "CLI",
             description: "Builds the swift-opa-cli executable and its dependencies."
         ),
+        Trait(
+            name: "YAML",
+            description: "Builds the yaml.* builtins and their Yams dependency."
+        ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.5.0"),
+        .package(url: "https://github.com/jpsim/Yams", from: "6.2.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -56,6 +61,7 @@ let package = Package(
                 "IR",
                 "Bytecode",
                 .product(name: "Crypto", package: "swift-crypto", condition: .when(platforms: [.linux])),
+                .product(name: "Yams", package: "Yams", condition: .when(traits: ["YAML"])),
             ]
         ),
         // Internal module tests

--- a/README.md
+++ b/README.md
@@ -80,22 +80,31 @@ let package = Package(
 
 ### Traits and Minimal Builds
 
-Swift-OPA ships a `swift-opa-cli` executable that depends on
-[swift-argument-parser](https://github.com/apple/swift-argument-parser). This is enabled
-by default via the `CLI` package trait.
+Swift-OPA exposes two optional features behind default-enabled package traits:
 
-Library-only consumers who only want the VM can disable the trait to drop the CLI and
-its dependencies entirely on newer Swift toolchain versions:
+- **`CLI`** — builds the `swift-opa-cli` executable. Depends on
+  [swift-argument-parser](https://github.com/apple/swift-argument-parser).
+- **`YAML`** — builds the `yaml.is_valid`, `yaml.marshal`, and `yaml.unmarshal`
+  builtins. Depends on [Yams](https://github.com/jpsim/Yams).
+
+Both are enabled by default. Library-only consumers who only want the VM can disable
+either or both traits to drop those features and their dependencies entirely on newer
+Swift toolchain versions:
 
 ```swift
 dependencies: [
     .package(
         url: "https://github.com/open-policy-agent/swift-opa",
-        branch: "main",
-        traits: []   // disables the default "CLI" trait; swift-argument-parser is not fetched
+        from: "<latest version>",
+        traits: []   // Disables all traits. Optional dependencies not fetched.
     ),
 ],
 ```
+
+To keep only some features, list the traits you want to enable, e.g.
+`traits: ["YAML"]` builds the `yaml.*` builtins but drops the CLI. When the `YAML`
+trait is disabled, the `yaml.*` builtins are not registered.
+
 
 ## Usage
 

--- a/Sources/Rego/Builtins/Registry.swift
+++ b/Sources/Rego/Builtins/Registry.swift
@@ -116,7 +116,7 @@ public struct BuiltinRegistry: Sendable {
     }
 
     internal static var defaultBuiltins: [String: SyncBuiltin] {
-        return [
+        var builtins: [String: SyncBuiltin] = [
             // Aggregates
             "count": BuiltinFuncs.count,
             "max": BuiltinFuncs.max,
@@ -294,6 +294,16 @@ public struct BuiltinRegistry: Sendable {
             // Walk
             "walk": BuiltinFuncs.walk,
         ]
+
+        // Encoding (YAML): Gated behind the optional "YAML" package trait, which
+        // controls whether the Yams dependency is resolved and compiled in.
+        #if YAML
+            builtins["yaml.is_valid"] = BuiltinFuncs.yamlIsValid
+            builtins["yaml.marshal"] = BuiltinFuncs.yamlMarshal
+            builtins["yaml.unmarshal"] = BuiltinFuncs.yamlUnmarshal
+        #endif
+
+        return builtins
     }
 
     public subscript(name: String) -> AsyncBuiltin? {

--- a/Sources/Rego/Builtins/Yaml.swift
+++ b/Sources/Rego/Builtins/Yaml.swift
@@ -1,0 +1,52 @@
+#if YAML
+    import AST
+    import Foundation
+    import Yams
+
+    extension BuiltinFuncs {
+        // MARK: - yaml.is_valid
+        /// Verifies the input string is a valid YAML document.
+        public static func yamlIsValid(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+            guard args.count == 1 else {
+                throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+            }
+
+            // Matches OPA: a non-string argument is not a builtin error; it simply
+            // isn't valid YAML, so we return false rather than throwing.
+            guard case .string(let rawYAML) = args[0] else {
+                return AST.RegoValue(booleanLiteral: false)
+            }
+
+            // The result of the YAML parsing should be nil if parsing fails, or we got an empty input.
+            return AST.RegoValue(booleanLiteral: (try? Yams.load(yaml: rawYAML)) != nil)
+        }
+
+        // MARK: - yaml.marshal
+        /// Serializes the input term to YAML.
+        public static func yamlMarshal(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+            guard args.count == 1 else {
+                throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+            }
+
+            let encoder = YAMLEncoder()
+            let data = try encoder.encode(args[0])
+
+            return AST.RegoValue(stringLiteral: data)
+        }
+
+        // MARK: - yaml.unmarshal
+        /// Deserializes the input YAML string to a term.
+        public static func yamlUnmarshal(ctx: BuiltinContext, args: [AST.RegoValue]) throws -> AST.RegoValue {
+            guard args.count == 1 else {
+                throw Rego.BuiltinError.argumentCountMismatch(got: args.count, want: 1)
+            }
+
+            guard case .string(let rawYAML) = args[0] else {
+                throw BuiltinError.argumentTypeMismatch(arg: "x", got: args[0].typeName, want: "string")
+            }
+
+            let decoder = YAMLDecoder()
+            return try decoder.decode(AST.RegoValue.self, from: rawYAML)
+        }
+    }
+#endif

--- a/Tests/RegoTests/BuiltinTests/YamlTests.swift
+++ b/Tests/RegoTests/BuiltinTests/YamlTests.swift
@@ -1,0 +1,136 @@
+#if YAML
+    import AST
+    import Foundation
+    import Testing
+
+    @testable import Rego
+
+    extension BuiltinTests {
+        @Suite("BuiltinTests - Yaml", .tags(.builtins))
+        struct YamlTests {}
+    }
+
+    extension BuiltinTests.YamlTests {
+        static let yamlIsValidTests: [BuiltinTests.TestCase] = [
+            BuiltinTests.TestCase(
+                description: "valid yaml",
+                name: "yaml.is_valid",
+                args: [
+                    """
+                    foo:
+                    - qux: bar
+                    - baz: 2
+                    """
+                ],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "invalid yaml",
+                name: "yaml.is_valid",
+                args: [
+                    """
+                    foo:
+                    - qux: bar
+                    - baz: {
+                    """
+                ],
+                expected: .success(.boolean(false))
+            ),
+            BuiltinTests.TestCase(
+                description: "json ok",
+                name: "yaml.is_valid",
+                args: [
+                    "{\"json\": \"ok\"}"
+                ],
+                expected: .success(.boolean(true))
+            ),
+            BuiltinTests.TestCase(
+                description: "invalid - non string",
+                name: "yaml.is_valid",
+                args: [["foo": 1]],
+                expected: .success(.boolean(false))  // Matches OPA: returns false rather than throwing.
+            ),
+        ]
+
+        static let yamlMarshalTests: [BuiltinTests.TestCase] = [
+            BuiltinTests.TestCase(
+                description: "nested object and list",
+                name: "yaml.marshal",
+                args: [
+                    [["foo": [1, 2, 3]]]
+                ],
+                expected: .success(
+                    """
+                    - foo:
+                      - 1
+                      - 2
+                      - 3
+
+                    """
+                )
+            )
+        ]
+
+        static let yamlUnmarshalTests: [BuiltinTests.TestCase] = [
+            BuiltinTests.TestCase(
+                description: "nested object and list",
+                name: "yaml.unmarshal",
+                args: [
+                    """
+                    - foo:
+                      - 1
+                      - 2
+                      - 3
+                    """
+                ],
+                expected: .success([["foo": [1, 2, 3]]])
+            )
+        ]
+
+        static var allTests: [BuiltinTests.TestCase] {
+            [
+                // yaml.is_valid's documentation states it requires a string, but
+                // like OPA, it does not throw on a wrong-typed argument. In those
+                // cases it returns false.
+                BuiltinTests.generateFailureTests(
+                    builtinName: "yaml.is_valid",
+                    sampleArgs: [
+                        """
+                        - 1
+                        - 2
+                        - 3
+                        """
+                    ],
+                    argIndex: 0, argName: "x",
+                    allowedArgTypes: ["undefined", "null", "boolean", "number", "string", "object", "array", "set"],
+                    generateNumberOfArgsTest: true),
+                BuiltinTests.generateFailureTests(
+                    builtinName: "yaml.marshal",
+                    sampleArgs: [["x": 2]],
+                    argIndex: 0, argName: "x",
+                    allowedArgTypes: ["undefined", "boolean", "null", "number", "string", "array", "object", "set"],
+                    generateNumberOfArgsTest: true),
+                BuiltinTests.generateFailureTests(
+                    builtinName: "yaml.unmarshal",
+                    sampleArgs: [
+                        """
+                        - 1
+                        - 2
+                        - 3
+                        """
+                    ],
+                    argIndex: 0, argName: "x",
+                    allowedArgTypes: ["string"],
+                    generateNumberOfArgsTest: true),
+                yamlIsValidTests,
+                yamlMarshalTests,
+                yamlUnmarshalTests,
+            ].flatMap { $0 }
+        }
+
+        @Test(arguments: allTests)
+        func testBuiltins(tc: BuiltinTests.TestCase) async throws {
+            try await BuiltinTests.testBuiltin(tc: tc)
+        }
+    }
+#endif

--- a/capabilities.json
+++ b/capabilities.json
@@ -2967,6 +2967,48 @@
       },
       "name" : "walk",
       "relation" : true
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
+          "type" : "boolean"
+        },
+        "type" : "function"
+      },
+      "name" : "yaml.is_valid"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "any"
+          }
+        ],
+        "result" : {
+          "type" : "string"
+        },
+        "type" : "function"
+      },
+      "name" : "yaml.marshal"
+    },
+    {
+      "decl" : {
+        "args" : [
+          {
+            "type" : "string"
+          }
+        ],
+        "result" : {
+          "type" : "any"
+        },
+        "type" : "function"
+      },
+      "name" : "yaml.unmarshal"
     }
   ],
   "features" : [


### PR DESCRIPTION
### What code changed, and why?

This PR adds support for OPA's `yaml.*` builtins, and gates their library dependency behind a new default-enabled `YAML` trait.

### How to test

 - New tests have been added that also enable themselves when the `YAML` trait is on.
   - These tests run by default, because the trait is on by default.

### Related Resources

